### PR TITLE
Gestion correcte des boutons de formulaires avec le clavier virtuel

### DIFF
--- a/config-production.xml
+++ b/config-production.xml
@@ -21,9 +21,10 @@
   
   <plugin name="cordova-plugin-device" spec="https://github.com/Addarkar/cordova-plugin-cookie-manager.git#51672c23204e1041fca651611aac6bc65a0759e3" />
   <plugin name="cordova-plugin-geolocation" spec="~4.0.1" />
-  <plugin name="cordova-plugin-whitelist" spec="~1.3.3" />
-  <plugin name="cordova-plugin-statusbar" spec="~2.4.1" />
+  <plugin name="cordova-plugin-ionic-keyboard" spec="~2.0.5" />
   <plugin name="cordova-plugin-splashscreen" spec="https://github.com/apache/cordova-plugin-splashscreen.git" />
+  <plugin name="cordova-plugin-statusbar" spec="~2.4.1" />
+  <plugin name="cordova-plugin-whitelist" spec="~1.3.3" />
 
   <preference name="orientation" value="portrait" />
   <preference name="phonegap-version" value="cli-8.0.0" />

--- a/src/pages/SigninPage.js
+++ b/src/pages/SigninPage.js
@@ -20,33 +20,35 @@ const Label = ({ title }) => {
 const SigninPage = ({ errors }) => {
   return (
     <main className='page sign-page red'>
-      <div className='mt3'>
-        <div className='h1 mb1 semibold'>
-          Bonjour!
+      <div className='form-container'>
+        <div className='mt3'>
+          <div className='h1 mb1 semibold'>
+            Bonjour!
+          </div>
+          <div>
+            Identifiez-vous <br/>
+            pour accéder aux offres
+          </div>
         </div>
-        <div>
-          Identifiez-vous <br/>
-          pour accéder aux offres
+        <form className='mb4'>
+          <FormField className={inputClassName}
+            type='email'
+            collectionName='users'
+            label={<Label title='Adresse e-mail:' />}
+            name='identifier'
+            placeholder='Identifiant (email)'
+            autoComplete='email' />
+          <FormField className={inputClassName}
+            collectionName='users'
+            label={<Label title='Mot de passe' />}
+            name='password'
+            type='password'
+            placeholder='Mot de passe'
+            autoComplete='current-password' />
+        </form>
+        <div className='sign__error mt1'>
+          {errors}
         </div>
-      </div>
-      <form className='mb4'>
-        <FormField className={inputClassName}
-          type='email'
-          collectionName='users'
-          label={<Label title='Adresse e-mail:' />}
-          name='identifier'
-          placeholder='Identifiant (email)'
-          autoComplete='email' />
-        <FormField className={inputClassName}
-          collectionName='users'
-          label={<Label title='Mot de passe' />}
-          name='password'
-          type='password'
-          placeholder='Mot de passe'
-          autoComplete='current-password' />
-      </form>
-      <div className='sign__error mt1'>
-        {errors}
       </div>
       <footer>
         <NavLink to='/inscription'>

--- a/src/pages/SignupPage.js
+++ b/src/pages/SignupPage.js
@@ -23,50 +23,52 @@ const Label = ({ isJumpLine, subtitle, title }) => (
 const SignupPage = ({ errors }) => {
   return (
     <main className='page sign-page'>
-      <p>Une minute pour créer un compte, et puis c'est tout !</p>
-      <form className='p2'>
-        <FormField className='input'
-                   label={
-                     <Label isJumpLine
-                            title='Identifiant'
-                            subtitle='...que verront les autres utilisateurs:' />
-                   }
-                   required='true'
-                   collectionName='users'
-                   name='publicName'
-                   autoComplete='name'
-                   placeholder='Rosa'
-                   type='text' />
-        <FormField className='input'
-                   label={
-                     <Label isJumpLine
-                            title='Adresse e-mail'
-                            subtitle="...pour se connecter et récupérer son mot de passe en cas d'oubli:" />
-                   }
-                   collectionName='users'
-                   required='true'
-                   autoComplete='email'
-                   name='email'
-                   type='email'
-                   placeholder='rose@domaine.fr' />
-        <FormField className='input'
-                   label={
-                     <Label title='Mot de passe'
-                            subtitle="...pour se connecter:" />
-                   }
-                   collectionName='users'
-                   required='true'
-                   autoComplete='new-password'
-                   name='password'
-                   placeholder='mot de passe'
-                   type='password' />
-        <FormField label={<span className="h4"> J'accepte d'être contacté par mail pour donner mon avis sur le <a href="http://passculture.beta.gouv.fr">Pass Culture</a></span>}
-                   collectionName='users'
-                   required='true'
-                   name='contact_ok'
-                   type='checkbox' />
-      </form>
-      <div className='errors'>{errors}</div>
+      <div className='form-container'>
+        <p>Une minute pour créer un compte, et puis c'est tout !</p>
+        <form className='p2'>
+          <FormField className='input'
+                     label={
+                       <Label isJumpLine
+                              title='Identifiant'
+                              subtitle='...que verront les autres utilisateurs:' />
+                     }
+                     required='true'
+                     collectionName='users'
+                     name='publicName'
+                     autoComplete='name'
+                     placeholder='Rosa'
+                     type='text' />
+          <FormField className='input'
+                     label={
+                       <Label isJumpLine
+                              title='Adresse e-mail'
+                              subtitle="...pour se connecter et récupérer son mot de passe en cas d'oubli:" />
+                     }
+                     collectionName='users'
+                     required='true'
+                     autoComplete='email'
+                     name='email'
+                     type='email'
+                     placeholder='rose@domaine.fr' />
+          <FormField className='input'
+                     label={
+                       <Label title='Mot de passe'
+                              subtitle="...pour se connecter:" />
+                     }
+                     collectionName='users'
+                     required='true'
+                     autoComplete='new-password'
+                     name='password'
+                     placeholder='mot de passe'
+                     type='password' />
+          <FormField label={<span className="h4"> J'accepte d'être contacté par mail pour donner mon avis sur le <a href="http://passculture.beta.gouv.fr">Pass Culture</a></span>}
+                     collectionName='users'
+                     required='true'
+                     name='contact_ok'
+                     type='checkbox' />
+        </form>
+        <div className='errors'>{errors}</div>
+      </div>
       <footer className='flex items-center'>
         <NavLink to='/connexion'>
           Déjà inscrit ?

--- a/src/styles/pages/SignPage.scss
+++ b/src/styles/pages/SignPage.scss
@@ -101,6 +101,6 @@ body.web .sign-page {
   min-height: 100vh;
   height: auto;
   .form-container {
-    min-height: calc(100vh - 5rem);
+    flex: 1;
   }
 }

--- a/src/styles/pages/SignPage.scss
+++ b/src/styles/pages/SignPage.scss
@@ -1,13 +1,19 @@
 .sign-page {
 
-  padding: 1rem;
-  color: $black;
-  display: flex;
-  font-size: 1.2rem;
-  flex-direction: column;
-  min-height: 100vh;
-  justify-content: space-around;
-  padding-bottom: 5rem;
+  height: 100vh;
+
+  .form-container {
+    overflow-y: auto;
+    justify-content: space-between;
+    flex-direction: column;
+    padding: 1rem;
+    display: flex;
+    color: $black;
+    font-size: 1.2rem;
+    position: absolute;
+    top: 0;
+    bottom: 5rem;
+  }
 
   a {
     color: $black;
@@ -81,5 +87,16 @@
   .button--secondary {
     font-size: 1.3rem;
     line-height: 1rem;
+  }
+}
+
+.softkeyboard .sign-page {
+  height: auto;
+  min-height: 100vh;
+  .form-container {
+    position: static;
+  }
+  footer {
+    position: static;
   }
 }

--- a/src/styles/pages/SignPage.scss
+++ b/src/styles/pages/SignPage.scss
@@ -1,18 +1,23 @@
 .sign-page {
 
+  color: $black;
+  display: flex;
+  font-size: 1.2rem;
+  flex-direction: column;
   height: 100vh;
+  padding-bottom: 5rem;
 
   .form-container {
-    overflow-y: auto;
-    justify-content: space-between;
-    flex-direction: column;
-    padding: 1rem;
     display: flex;
-    color: $black;
-    font-size: 1.2rem;
-    position: absolute;
-    top: 0;
-    bottom: 5rem;
+    flex-direction: column;
+    min-height: 100%;
+    overflow-y: auto;
+    padding: 1rem;
+  }
+
+  form {
+    margin-top: auto;
+    margin-bottom: auto;
   }
 
   a {
@@ -61,6 +66,7 @@
     transition: transform .2s ease-in-out;
     &.pop {
       transform: scale(1.04);
+      transform-origin: 0 50%;
     }
     img {
       vertical-align: middle;
@@ -90,13 +96,11 @@
   }
 }
 
-.softkeyboard .sign-page {
-  height: auto;
+body.softkeyboard .sign-page,
+body.web .sign-page {
   min-height: 100vh;
+  height: auto;
   .form-container {
-    position: static;
-  }
-  footer {
-    position: static;
+    min-height: calc(100vh - 5rem);
   }
 }

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -53,6 +53,7 @@ export const IS_LOCALHOST = Boolean(
 
 var CALC_ROOT_PATH = ''
 if (window.cordova) {
+  document.body.className += ' cordova'
   if (MOBILE_OS === 'android') {
     CALC_ROOT_PATH = 'file:///android_asset/www'
     //document.body.className += ' android-with-statusbar'
@@ -72,6 +73,9 @@ if (window.cordova) {
                                                                              .filter(c => c!=='softkeyboard')
                                                                              .join(' ')
                           });
+} else {
+  document.body.className += ' web'
 }
+
 
 export const ROOT_PATH = CALC_ROOT_PATH

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -60,6 +60,18 @@ if (window.cordova) {
     //TODO
     CALC_ROOT_PATH = window.location.href.substring(0,1)
   }
+  window.addEventListener('keyboardWillShow',
+                          function (e) {
+                            console.log("Keyboard show");
+                            document.body.className += ' softkeyboard'
+                          });
+  window.addEventListener('keyboardWillHide',
+                          function (e) {
+                            console.log("Keyboard Hide");
+                            document.body.className = document.body.className.split(' ')
+                                                                             .filter(c => c!=='softkeyboard')
+                                                                             .join(' ')
+                          });
 }
 
 export const ROOT_PATH = CALC_ROOT_PATH


### PR DESCRIPTION
Le principe : 

Avoir les boutons de formulaire en bas d'écran autant que possible, tout en préservant un scroll correct. Ne pas avoir les boutons qui remontent lorsqu'on ouvre le clavier virtuel, ne pas perturber les fonctionnalités de scroll automatique vers l'input en cours lorsqu'on ouvre le clavier (ce qui nécessite que le scroll se fasse sur le body ou une div qui fait 100% du body et pas une sous-div d'après mes tests).

Limitation: pas de moyen fiable de detecter le clavier virtuel en web.

Donc:
- boutons (footer) en position:absolute bottom:0 dans l'appli clavier fermé avec scroll sur le conteneur au dessus des boutons
- boutons (footer) en position:static, mais min-height qui pousse les boutons en bas de l'écran dans l'appli clavier ouvert ou sur le web avec scroll sur l'écran complet

Ça ne permet pas d'éviter le scroll pour cliquer le bouton en web si jamais le form dépasse les 100vh (ce qui est le cas de notre formulaire d'inscription sur la plupart des appareils mobiles), mais je doute qu'on puisse faire mieux.


