### PR TITLE
Move gradient to card

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -213,6 +213,7 @@ class Card extends Component {
       isLast,
       isTransitioning,
       item,
+      transitionTimeout
     } = this.props
     const { position,
       style,
@@ -245,7 +246,7 @@ class Card extends Component {
             ref={element => this.cardElement = element}
             style={style}>
             <div className='card__container' style={{ transform }}>
-              <Recto {...content} />
+              <Recto transitionTimeout={transitionTimeout} {...content} />
             </div>
           </span>
       </Draggable>,

--- a/src/components/Deck.js
+++ b/src/components/Deck.js
@@ -114,29 +114,6 @@ class Deck extends Component {
     // update
     this.setState({ currentContent, previousContent, nextContent })
   }
-  handleSetStyle = () => {
-    // unpack
-    const { currentContent } = this
-    const { transitionTimeout } = this.props
-    // style
-    const buttonStyle = { transition: `opacity ${transitionTimeout}ms` }
-    const style = {
-      backgroundColor: 'black',
-      transition: `background-color ${transitionTimeout}ms`
-    }
-    const gradientStyle = {
-      background: 'linear-gradient(transparent, black)',
-      transition: `background ${transitionTimeout}ms`
-    }
-    if (currentContent && currentContent.backgroundColor) {
-      const [red, green, blue] = currentContent.backgroundColor
-      const hue = rgb_to_hsv({r: red, g: green, b: blue}).h
-      style.backgroundColor = `hsl(${hue}, 100%, 15%)`
-      gradientStyle.background = `linear-gradient(transparent, hsl(${hue}, 100%, 15%))`
-    }
-    // update
-    this.setState({ buttonStyle, gradientStyle, style })
-  }
   handleSetReadCard = card => {
     // unpack
     const { handleSetReadCard, isDebug } = this.props
@@ -290,11 +267,6 @@ class Deck extends Component {
       isDebug && debug('Deck - componentDidUpdate handleSetCurrentContent')
       this.handleSetCurrentContent()
     }
-    // adapt style given current content
-    if (transitionTimeout !== prevProps.transitionTimeout ||
-      currentContent !== prevState.currentContent) {
-      this.handleSetStyle()
-    }
   }
   componentWillUnmount () {
     window.removeEventListener('resize', this.onDebouncedResize)
@@ -322,7 +294,7 @@ class Deck extends Component {
       readTimeout,
       headerColor,
     } = this.props
-    const { buttonStyle,
+    const { 
       currentContent,
       cursor,
       deckElement,
@@ -354,7 +326,10 @@ class Deck extends Component {
         onStop={onStop} >
         <div className='deck'
           id='deck'
-          style={style}
+          style={{
+                  backgroundColor: headerColor,
+                  transition: `background-color ${transitionTimeout}ms`,
+                }}
           ref={element => this.element = element }>
           {!this.props.unFlippable && (
             <button className={classnames('button close', {
@@ -396,18 +371,14 @@ class Deck extends Component {
           <div className='board-wrapper'>
             <div className='board'
               id='deck__board'
-              ref={element => this.boardElement = element}
-              style={{
-                background: `linear-gradient(to bottom, rgba(0,0,0,0) 0%,${headerColor} 35%,${headerColor} 100%)`,
-              }} >
+              ref={element => this.boardElement = element} >
               <ul className='controls' style={{backgroundImage: `url('${ROOT_PATH}/mosaic-w.svg')`,}}>
                 <li>
                   <button className={classnames('button before', {
                     'disabled': isBeforeDisabled,
                     'hidden': isBeforeHidden })}
                     disabled={isBeforeDisabled || isBeforeHidden}
-                    onClick={event => onNext(event, 1)}
-                    style={buttonStyle}>
+                    onClick={event => onNext(event, 1)} >
                       <Icon svg='ico-prev-w-group' />
                   </button>
                 </li>
@@ -415,8 +386,7 @@ class Deck extends Component {
                   <button className={classnames('button to-recto ', {
                     'disabled': isFlipDisabled,
                     'hidden': isLoading || isFlipDisabled })}
-                    onClick={e => this.props.flip()}
-                    style={buttonStyle} >
+                    onClick={e => this.props.flip()} >
                     <Icon svg='ico-slideup-w' />
                   </button>
                   <Clue />
@@ -426,8 +396,7 @@ class Deck extends Component {
                     'disabled': isAfterDisabled,
                     'hidden': isAfterHidden })}
                     onClick={event => onNext(event, -1)}
-                    disabled={isAfterDisabled || isAfterHidden}
-                    style={buttonStyle} >
+                    disabled={isAfterDisabled || isAfterHidden} >
                     <Icon svg='ico-next-w-group' />
                   </button>
                 </li>
@@ -446,7 +415,7 @@ Deck.defaultProps = { deckKey: 0,
   isDebug: false,
   readTimeout: 3000,
   resizeTimeout: 250,
-  transitionTimeout: 500
+  transitionTimeout: 500,
 }
 
 export default connect(

--- a/src/components/Recto.js
+++ b/src/components/Recto.js
@@ -7,6 +7,7 @@ import RectoDebug from './RectoDebug'
 import withSelectors from '../hocs/withSelectors'
 import { getOffer } from '../selectors/offer'
 import { getMediation } from '../selectors/mediation'
+import selectHeaderColor from '../selectors/headerColor'
 import selectOffer from '../selectors/offer'
 import { getSource } from '../selectors/source'
 import { getThumbUrl } from '../selectors/thumbUrl'
@@ -37,11 +38,13 @@ class Recto extends Component {
   }
 
   render () {
-    const { isFromLoading,
-      mediation,
-      isLoading,
-      thumbUrl,
+    const { headerColor,
       isFlipped,
+      isFromLoading,
+      isLoading,
+      mediation,
+      thumbUrl,
+      transitionTimeout,
     } = this.props
     const { isRemoveLoading } = this.state
     const backgroundStyle = { backgroundImage: `url('${thumbUrl}')` };
@@ -72,6 +75,11 @@ class Recto extends Component {
           })} />
         )}
         {IS_DEV && <RectoDebug {...this.props} />}
+        <div className='card-gradient'
+              style={{
+              transition: `background ${transitionTimeout}ms`,
+              background: `linear-gradient(to bottom, rgba(0,0,0,0) 0%,${headerColor} 75%,${headerColor} 100%)`
+              }} />
      </div>
     )
   }
@@ -82,6 +90,7 @@ export default compose(
     (state, ownProps) => ({
       currentOffer: selectOffer(state),
       currentUserMediation: selectUserMediation(state),
+      headerColor: selectHeaderColor(state),
       isFlipped: state.verso.isFlipped,
       userMediations: state.data.userMediations
     })),

--- a/src/styles/components/Recto.scss
+++ b/src/styles/components/Recto.scss
@@ -23,6 +23,13 @@
     margin-left: -50px;
     transition: all 0.25s ease-out;
   }
+  .card-gradient {
+    position: absolute;
+    bottom: 0;
+    height: 15%;
+    width: 100%;
+    z-index: 100;
+  }
   .loading {
     background-color: $menu-red;
     position: absolute;
@@ -31,7 +38,7 @@
     left: 0;
     right: 0;
     transition: opacity 1s, z-index 10ms 0.75s;
-    z-index: 1000;
+    z-index: 99;
     filter: none;
     div {
       color: white;


### PR DESCRIPTION
Passe le gradient dans le Verso.js pour qu'il bouge avec les cartes, ce qui évite les recalculs d'opacité et apporte un gain (malheureusement très modéré) de performances. Ça permettra aussi d'animer le gradient en en ayant deux et en faisant une transition d'opacité de l'un à l'autre.

On peut probablement faire encore mieux en ayant un seul gradient pour toutes les cartes, qui bouge avec toutes les cartes.