### PR TITLE
[WIP] Re reselect

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prop-types": "^15.6.0",
     "query-string": "5",
     "raf": "3.4.0",
+    "re-reselect": "^2.1.0",
     "react": "^0.14||^15.5.4||^16.1.1",
     "react-dates": "augnustin/react-dates#pass-culture",
     "react-dev-utils": "^4.2.1",

--- a/src/reducers/data.js
+++ b/src/reducers/data.js
@@ -5,7 +5,12 @@ const REMOVE_DATA_ERROR = 'REMOVE_DATA_ERROR'
 const RESET_DATA = 'RESET_DATA'
 
 // INITIAL STATE
-const initialState = { referenceDate: null, isOptimist: false }
+const initialState = {
+  referenceDate: null,
+  isOptimist: false,
+  bookings: [],
+  recommendations: [],
+}
 
 // REDUCER
 const data = (state = initialState, action) => {

--- a/src/selectors/booking.js
+++ b/src/selectors/booking.js
@@ -1,14 +1,12 @@
 import get from 'lodash.get'
-import { createSelector } from 'reselect'
+import createCachedSelector from 're-reselect';
 
-import selectCurrentRecommendation from './currentRecommendation'
+import recommendationSelector from './recommendation'
 
-export default createSelector(
+export default createCachedSelector(
   state => state.data.bookings,
-  selectCurrentRecommendation,
+  state => recommendationSelector(state),
   (bookings, recommendation) => {
-    return []
-      .concat(bookings)
-      .find(b => get(b, 'recommendationId') === get(recommendation, 'id'))
+    return bookings.find(b => get(b, 'recommendationId') === get(recommendation, 'id'))
   }
-)
+)()

--- a/src/selectors/booking.js
+++ b/src/selectors/booking.js
@@ -5,8 +5,10 @@ import recommendationSelector from './recommendation'
 
 export default createCachedSelector(
   state => state.data.bookings,
-  state => recommendationSelector(state),
+  (state, recommendationId) => recommendationSelector(state, recommendationId),
   (bookings, recommendation) => {
     return bookings.find(b => get(b, 'recommendationId') === get(recommendation, 'id'))
   }
-)()
+)(
+  (state, recommendationId) => recommendationId || ''
+)

--- a/src/selectors/recommendation.js
+++ b/src/selectors/recommendation.js
@@ -1,0 +1,11 @@
+import createCachedSelector from 're-reselect';
+
+import recommendationsSelector from './recommendations'
+
+export default createCachedSelector(
+  state => recommendationsSelector(state),
+  (state, recommendationId) => recommendationId,
+  (recommendations, recommendationId) => recommendations.find(r => r.id === recommendationId)
+)(
+  (state, recommendationId) => recommendationId || ''
+)

--- a/src/selectors/recommendations.js
+++ b/src/selectors/recommendations.js
@@ -1,0 +1,15 @@
+import createCachedSelector from 're-reselect';
+
+export default createCachedSelector(
+  state => state.data.recommendations,
+  (state, mediationId) => mediationId,
+  (recommendations, mediationId) => {
+    recommendations = recommendations.map((r, index) => Object.assign({}, r, {index}))
+    // TODO: add headerColor
+    if (mediationId)
+      recommendations = recommendations.filter(r => r.mediationId === mediationId)
+    return recommendations
+  }
+)(
+  (state, offererId, mediationId) => `${offererId || ''}/${mediationId || ''}`
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -6887,6 +6887,10 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+re-reselect@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/re-reselect/-/re-reselect-2.1.0.tgz#dc6d04c9f60752f8e0af5bbb1bffaabcedd13928"
+
 react-addons-shallow-compare@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz#198a00b91fc37623db64a28fd17b596ba362702f"


### PR DESCRIPTION
Je n'ai pas du tout terminé, mais la philosophie générale c'est:

- pour les collections, mettre la valeur par défaut `[]` dans le reducer `data`
- changer le `createSelector` par `createCachedSelector`
- pour chaque type d'objet, faire un *collection retriever*. Eg. `recommendations`, et un *element retriever*, qui basiquement appelle le *collection retriever* puis prend un `id` en paramètre

Je ne supprime pas les anciens sélecteurs pour le moment.

A priori on ne devrait plus avoir besoin des getters non plus, sauf si j'ai loupé quelque chose.

Il y a moins de sélecteurs que dans pro, donc ça devrait bien se passer, même si effectivement c'est un bon bordel ^^.

Si c'est pas urgent, je peux reprendre la main, mais ça devra attendre mercredi prochain.