### PR TITLE
PR Menu avec Scroll ios/android/web

### DIFF
--- a/src/components/MainMenu.js
+++ b/src/components/MainMenu.js
@@ -5,8 +5,8 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { compose } from 'redux'
 import { Transition } from 'react-transition-group'
-import { Scrollbars } from 'react-custom-scrollbars'
 import { withRouter } from 'react-router-dom'
+// import { Scrollbars } from 'react-custom-scrollbars'
 
 import routes from '../utils/routes'
 import MenuItem from './menu/MenuItem'
@@ -70,28 +70,24 @@ class MainMenu extends React.PureComponent {
     const { isVisible, user } = this.props
     return (
       <Transition in={isVisible} timeout={transitionDelay}>
-        {state => (
+        {status => (
           <div
             id="main-menu"
-            className="is-overlay p12 flex-rows flex-end"
-            style={{ ...defaultStyle, ...transitionStyles[state] }}
+            className={`is-overlay ${status}`}
+            style={{ ...defaultStyle, ...transitionStyles[status] }}
           >
-            <div className="inner is-relative is-clipped">
-              {this.renderCloseButton()}
-              <div id="main-menu-fixed-container">
-                <Scrollbars autoHide>
-                  <div className="scroll-container pc-theme-red">
-                    <MenuHeader user={user} />
-                    {/* <!-- Navigation Items --> */}
-                    <nav
-                      id="main-menu-navigation"
-                      className="flex-rows mt16 pb0"
-                    >
-                      {this.renderNavigationLinks()}
-                    </nav>
-                    {/* <!-- Navigation Items --> */}
-                  </div>
-                </Scrollbars>
+            <div className="inner is-full-layout is-relative flex-rows flex-end">
+              <div className="pc-scroll-container">
+                <div
+                  id="main-menu-fixed-container"
+                  className="pc-theme-red is-relative"
+                >
+                  {this.renderCloseButton()}
+                  <MenuHeader user={user} />
+                  <nav id="main-menu-navigation" className="flex-rows mt16 pb0">
+                    {this.renderNavigationLinks()}
+                  </nav>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/menu/MenuHeader.js
+++ b/src/components/menu/MenuHeader.js
@@ -25,7 +25,11 @@ const MenuHeader = ({ user }) => {
         <p className="fs30">
           <span>Mon Pass</span>
         </p>
-        <p id="main-menu-header-wallet-value" className="fs48">
+        <p
+          id="main-menu-header-wallet-value"
+          className="fs52 is-normal"
+          style={{ lineHeight: '42px' }}
+        >
           <span>{`${wallet}€`}</span>
         </p>
       </div>

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -10,7 +10,7 @@ const renderLinkContent = (icon, title, styles) => (
     <span style={styles} className="text-center menu-icon mr16 text-center">
       <Icon svg={`ico-${icon}`} alt="" />
     </span>
-    <span>
+    <span className="is-medium">
       {title}
     </span>
   </React.Fragment>

--- a/src/components/pages/profile/MonPassCulture.js
+++ b/src/components/pages/profile/MonPassCulture.js
@@ -83,8 +83,6 @@ const MonPassCulture = ({ user }) => {
   )
 }
 
-MonPassCulture.defaultProps = {}
-
 MonPassCulture.propTypes = {
   user: PropTypes.object.isRequired,
 }

--- a/src/styles/components/index.scss
+++ b/src/styles/components/index.scss
@@ -6,7 +6,7 @@
 @import 'Card.scss';
 @import 'Deck.scss';
 @import 'DeckNavigation.scss';
-@import 'Menu.scss';
+@import 'main-menu.scss';
 @import 'Price.scss';
 @import 'Recto.scss';
 @import 'SearchFilter.scss';

--- a/src/styles/components/main-menu.scss
+++ b/src/styles/components/main-menu.scss
@@ -1,28 +1,39 @@
 $main-menu-height: 592px;
 $main-menu-header-height: 152px;
+$main-menu-around-padding: 12px;
+$main-menu-height-with-padding: (592px + 24px); // 24 === padding (2 * 12)
 
 #main-menu {
   z-index: $zindex-main-menu;
 }
 
-#main-menu .inner,
-#main-menu .scroll-container {
-  border-radius: rem(16px);
+#main-menu .pc-scroll-container {
+  height: auto;
+  min-height: auto;
+  max-height: auto;
+  overflow: hidden;
+  padding: $main-menu-around-padding;
+}
+
+@media (max-height: $main-menu-height-with-padding) {
+  // prevent scrollbar flickering
+  // cas du flickering car la hauteur est exactement egale a 616px
+  #main-menu .pc-scroll-container {
+    overflow: auto;
+  }
 }
 
 #main-menu-fixed-container {
-  height: 100%;
-}
-
-#main-menu .inner {
-  max-height: 100%;
+  border-radius: rem(16px);
   height: $main-menu-height;
+  max-height: $main-menu-height;
+  min-height: $main-menu-height;
 }
 
 #main-menu-close-button {
   z-index: 1;
-  top: rem(16px);
-  right: rem(16px);
+  top: rem(22px);
+  right: rem(22px);
 }
 
 #main-menu-header {
@@ -32,12 +43,12 @@ $main-menu-header-height: 152px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.4);
 
   .column-profile {
-    width: 40%;
+    width: 45%;
     min-width: 108px;
   }
 
   .column-account {
-    width: 60%;
+    width: 55%;
     border-left: 1px solid $white;
   }
 }

--- a/src/styles/helpers/_text.scss
+++ b/src/styles/helpers/_text.scss
@@ -1,6 +1,6 @@
 // creation des classes permettant de gerer la taille des polices
 // Exemple: .fs18, .fs32...
-$intSizes: (13, 14, 15, 16, 17, 18, 19, 20, 22, 30, 32, 48, 80);
+$intSizes: (13, 14, 15, 16, 17, 18, 19, 20, 22, 30, 32, 48, 52, 60, 80);
 
 @each $intSize in $intSizes {
   $pixelValue: number-to-pixel($intSize);


### PR DESCRIPTION
- Fixes #533
- suppr de la custom scrollbar
- rename menu.scss to main-menu.scss
- la hauteur du menu est harcoded dans le css à 592px
- utilisation d'une media queries si la hauteur de l'écran < 592 + padding (2 * 12)