### PR TITLE
767 reparer circle ci testcafe

### DIFF
--- a/src/selectors/tests/selectBookables.spec.js
+++ b/src/selectors/tests/selectBookables.spec.js
@@ -2,6 +2,8 @@
 import moment from 'moment'
 import { addModifierString, humanizeBeginningDate } from '../selectBookables'
 
+const format = 'dddd DD/MM/YYYY à HH:mm'
+
 describe('src | selectors| selectBookables', () => {
   describe('addModifierString', () => {
     it('Add property named __modifiers__ to array of objects', () => {
@@ -17,9 +19,9 @@ describe('src | selectors| selectBookables', () => {
   })
   describe('humanizeBeginningDate', () => {
     it('transform a date to an human readable one', () => {
-      const dateString = '2018-11-02T19:30:24Z'
-      const dateMoment = moment('2018-11-02T19:30:24Z')
-      const dateFomated = 'Friday 02/11/2018 à 20:30'
+      const dateString = new Date().toISOString()
+      const dateMoment = moment(dateString)
+      const dateExpected = dateMoment.format(format)
       let value = []
       let expected = []
       let result = addModifierString()(value)
@@ -37,12 +39,12 @@ describe('src | selectors| selectBookables', () => {
         { prop: 'prop' },
         {
           beginningDatetime: dateMoment,
-          humanBeginningDate: dateFomated,
+          humanBeginningDate: dateExpected,
           prop: 'prop',
         },
         {
           beginningDatetime: dateString,
-          humanBeginningDate: dateFomated,
+          humanBeginningDate: dateExpected,
           prop: 'prop',
         },
         {

--- a/testcafe/01_signup.js
+++ b/testcafe/01_signup.js
@@ -67,7 +67,7 @@ test('E-mail déjà présent dans la base et mot de passe invalide', async t => 
     )
     .typeText(userPassword, 'RTit.uioRZU.90')
     .click(signUpButton)
-    .wait(1000)
+    .wait(2000)
   await t
     .expect(userEmailError.innerText)
     .eql('Un compte lié à cet email existe déjà')

--- a/testcafe/01_signup.js
+++ b/testcafe/01_signup.js
@@ -45,6 +45,7 @@ test('Je crée un compte et je suis redirigé·e vers la page /découverte', asy
   const location = await t.eval(() => window.location)
   await t.expect(location.pathname).eql('/decouverte')
 })
+
 fixture(
   "01_02 SignupPage | Création d'un compte utilisateur | Messages d'erreur lorsque les champs ne sont pas correctement remplis"
 ).page(`${ROOT_PATH}inscription`)
@@ -60,11 +61,16 @@ test('E-mail déjà présent dans la base et mot de passe invalide', async t => 
     .click(signUpButton)
     .wait(1000)
   await t
-    .expect(userEmailError.innerText)
-    .eql('\nUn compte lié à cet email existe déjà\n\n')
-  await t
     .expect(userPasswordError.innerText)
-    .eql('\nVous devez saisir au moins 8 caractères.\n\n')
+    .eql(
+      'Le mot de passe doit faire au moins 12 caractères et contenir à minima 1 majuscule, 1 minuscule, 1 chiffre et 1 caractère spécial parmi _-&?~#|^@=+.$,<>%*!:;'
+    )
+    .typeText(userPassword, 'RTit.uioRZU.90')
+    .click(signUpButton)
+    .wait(1000)
+  await t
+    .expect(userEmailError.innerText)
+    .eql('Un compte lié à cet email existe déjà')
 })
 
 test('E-mail non autorisé', async t => {
@@ -79,5 +85,5 @@ test('E-mail non autorisé', async t => {
     .wait(1000)
   await t
     .expect(userEmailError.innerText)
-    .eql("\nAdresse non autorisée pour l'expérimentation\n\n")
+    .eql("Adresse non autorisée pour l'expérimentation")
 })

--- a/testcafe/02_signin.js
+++ b/testcafe/02_signin.js
@@ -1,13 +1,9 @@
-/**
- *
- * Lancer les tests en local
- * ./node_modules/.bin/testcafe chrome ./testcafe/02_signin.js  --env=local
- *
- */
-import { Selector } from 'testcafe'
+import { ClientFunction, Selector } from 'testcafe'
+import youngUser from './helpers/users'
 
 import { ROOT_PATH } from '../src/utils/config'
-import userFromSandboxDB from './helpers/users'
+
+const getPageUrl = ClientFunction(() => window.location.href.toString())
 
 const userId = '#user-identifier'
 const passId = '#user-password'
@@ -31,15 +27,15 @@ test('Je peux cliquer sur lien /inscription', async t => {
 
 test("Lorsque l'un des deux champs est manquant, le bouton connexion est désactivé", async t => {
   await t
-    .typeText(userIdentifier, userFromSandboxDB.email)
+    .typeText(userIdentifier, youngUser.email)
     .expect(signInButton.hasAttribute('disabled'))
     .ok()
 })
 
 test("J'ai un compte valide, je suis redirigé·e vers la page /decouverte sans erreurs", async t => {
   await t
-    .typeText(userIdentifier, userFromSandboxDB.email)
-    .typeText(userPassword, userFromSandboxDB.password)
+    .typeText(userIdentifier, youngUser.email)
+    .typeText(userPassword, youngUser.password)
     .click(signInButton)
     .wait(1000)
 
@@ -48,13 +44,13 @@ test("J'ai un compte valide, je suis redirigé·e vers la page /decouverte sans 
     .expect(identifierErrors.count)
     .eql(0)
     .expect(location.pathname)
-    .eql('/decouverte')
+  await t.expect(getPageUrl()).contains('/decouverte', { timeout: 1000 })
 })
 
 test("J'ai un identifiant invalide, je vois un messages d'erreur et je reste sur la page /connection", async t => {
   await t
     .typeText(userIdentifier, 'wrongEmail@test.com')
-    .typeText(userPassword, userFromSandboxDB.password)
+    .typeText(userPassword, youngUser.password)
     .click(signInButton)
     .wait(1000)
 
@@ -71,14 +67,14 @@ test("J'ai un identifiant invalide, je vois un messages d'erreur et je reste sur
 test("J'ai un mot de passe vide, avant envoi à l'API, je vois un message d'erreur et je reste sur la page /connection", async t => {
   await t
     // saisi du mot de passe
-    .typeText(userPassword, userFromSandboxDB.password)
+    .typeText(userPassword, youngUser.password)
     // puis on l'efface
     // - prevent testcafe de warn sur une valeur vide
     // TODO -> trouver une solution pour Blue le password input
     // faire plus propre
     .selectText(userPassword)
     .pressKey('delete')
-    .typeText(userIdentifier, userFromSandboxDB.email)
+    .typeText(userIdentifier, youngUser.email)
     // .click(signInButton)
     .wait(1000)
 
@@ -94,7 +90,7 @@ test("J'ai un mot de passe vide, avant envoi à l'API, je vois un message d'erre
 
 test("J'ai un mot de passe invalide, je vois un message d'erreur et je reste sur la page /connection", async t => {
   await t
-    .typeText(userIdentifier, userFromSandboxDB.email)
+    .typeText(userIdentifier, youngUser.email)
     .typeText(userPassword, 'Pa$$word4242')
     .click(signInButton)
     .wait(1000)

--- a/testcafe/05_search.js
+++ b/testcafe/05_search.js
@@ -8,8 +8,6 @@ const getPageUrl = ClientFunction(() => window.location.href.toString())
 const searchInput = Selector('#keywords')
 const keywordsSearchButton = Selector('#keywords-search-button')
 const searchTypeCheckbox = Selector('#search-type-checkbox').withText('Lire')
-// const refreshKeywordsButton = Selector('#refresh-keywords-button')
-// const searchResults = Selector('#search-results')
 const resultsTitle = Selector('#results-title')
 
 fixture
@@ -18,7 +16,7 @@ fixture
 
 test('Je suis redirigé vers la page /connexion', async t => {
   await t
-  await t.expect(getPageUrl()).contains('/connexion', { timeout: 5000 })
+  await t.expect(getPageUrl()).contains('/connexion', { timeout: 500 })
 })
 
 fixture('O5_02 Recherche | Après connexion').beforeEach(async t => {
@@ -27,7 +25,9 @@ fixture('O5_02 Recherche | Après connexion').beforeEach(async t => {
 
 test('Je peux accéder à la page /recherche', async t => {
   await t
-  await t.expect(getPageUrl()).contains('/recherche', { timeout: 5000 })
+    .wait(1000)
+    .expect(getPageUrl())
+    .contains('/recherche', { timeout: 5000 })
 })
 
 // HEADER
@@ -39,7 +39,7 @@ test('Je peux accéder à la page /recherche', async t => {
 // ------------------------ RECHERCHE PAR MOTS-CLES
 
 // ------------------------ NO RESULTS
-fixture.skip('O5_02 Recherche | Recherche textuelle').beforeEach(async t => {
+fixture.skip('O5_03 Recherche | Recherche textuelle').beforeEach(async t => {
   await t.useRole(regularUser).navigateTo(`${ROOT_PATH}recherche/categories`)
 })
 

--- a/testcafe/helpers/roles.js
+++ b/testcafe/helpers/roles.js
@@ -1,8 +1,9 @@
-import { Role, Selector } from 'testcafe'
+import { ClientFunction, Role, Selector } from 'testcafe'
 
 import { ROOT_PATH } from '../../src/utils/config'
 import youngUser from './users'
 
+const getPageUrl = ClientFunction(() => window.location.href.toString())
 const signInButton = Selector('button').withText('Connexion')
 
 const regularUser = Role(
@@ -14,8 +15,7 @@ const regularUser = Role(
       .wait(500)
       .click(signInButton)
       .wait(500)
-    const location = await t.eval(() => window.location)
-    await t.expect(location.pathname).eql('/decouverte')
+    await t.expect(getPageUrl()).contains('/decouverte', { timeout: 5000 })
   },
   {
     preserveUrl: true,


### PR DESCRIPTION
- le retour d'erreurs d'api avait changé
- on ne cherche plus une url exacte (par exemple /recherche) mais une url qui contient /recherche (car pour le moment, on n'a pas de base de test fixe et on voit les cartes découvertes)
