### PR TITLE
PC-1110 deck navigation broken on Firefox

### DIFF
--- a/src/components/pages/discovery/DeckNavigation.js
+++ b/src/components/pages/discovery/DeckNavigation.js
@@ -23,7 +23,7 @@ const toRectoDraggableBounds = {
 }
 
 function getPageY(event) {
-  if (event instanceof TouchEvent) {
+  if (window.TouchEvent && event instanceof TouchEvent) {
     const lastTouchIndex = event.changedTouches.length - 1
     return event.changedTouches[lastTouchIndex].pageY
   }

--- a/src/styles/components/DeckNavigation.scss
+++ b/src/styles/components/DeckNavigation.scss
@@ -37,7 +37,7 @@
 
 
 
-  .button.after img, .button.before img {
+  .button.after, .button.before {
     position: relative;
     z-index: $zindex-navigation-arrows;
   }


### PR DESCRIPTION
L'erreur en elle même ne cassait pas la navigation, le clic n'était pas pris en compte sur les button (flèche) de navigation car le z-index était setté sur l'image contenue par les boutons.

Sous chrome l'event "bubble" jusqu'au button container, mais pas sous FF.