### PR TITLE
453 - [POST PO REVIEW FIX] - removed Main from index of discovery page

### DIFF
--- a/scripts/pc.js
+++ b/scripts/pc.js
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 const childProcess = require('child_process')
-const fs =  require('fs')
+const fs = require('fs')
 const program = require('commander')
 const env = require('node-env-file')
-const path =  require('path')
+const path = require('path')
 
 const fileDir = path.join(__dirname, '/../env_file')
-if (fs.existsSync(fileDir)) { env(fileDir) }
+if (fs.existsSync(fileDir)) {
+  env(fileDir)
+}
 
 program
   .version('0.1.0')
@@ -17,16 +19,13 @@ program
   .option('-e, --environment [type]', 'Define environment', 'development')
   .option('-f, --file [type]', 'Define file', '')
 
-  .parse(process.argv);
+  .parse(process.argv)
 
-const { environment, testcafe } = program
-const NODE_ENV = environment === 'local'
-  ? 'development'
-  : environment
+const { browser, environment, file, testcafe } = program
+const NODE_ENV = environment === 'local' ? 'development' : environment
 
 if (testcafe) {
-  const { browser, environment, file } = program
-  const debugOption = environment === 'local' ? '-d' : ''
-  const command = `NODE_ENV=${NODE_ENV} testcafe ${browser} ${debugOption} testcafe/${file}`
+  const debugOption = program.environment === 'local' ? '-d' : ''
+  const command = `NODE_ENV=${NODE_ENV} ./node_modules/testcafe/bin/testcafe.js ${browser} ${debugOption} testcafe/${file}`
   childProcess.execSync(command, { stdio: [0, 1, 2] })
 }

--- a/src/components/pages/discovery/tests/__snapshots__/index.spec.js.snap
+++ b/src/components/pages/discovery/tests/__snapshots__/index.spec.js.snap
@@ -5,9 +5,44 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <RawDiscoveryPage
     backButton={true}
-    dispatch={[MockFunction]}
+    dispatch={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {
+              "config": Object {
+                "body": Object {
+                  "readRecommendations": null,
+                  "seenRecommendationIds": null,
+                },
+                "handleFail": [Function],
+                "handleSuccess": [Function],
+                "normalizer": Object {
+                  "bookings": "bookings",
+                },
+              },
+              "method": "PUT",
+              "path": "recommendations?",
+              "type": "REQUEST_DATA_PUT_RECOMMENDATIONS?",
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      }
+    }
     history={Object {}}
+    location={
+      Object {
+        "search": "",
+      }
+    }
     match={Object {}}
+    readRecommendations={null}
     recommendations={null}
   />,
   Symbol(enzyme.__renderer__): Object {
@@ -23,25 +58,57 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "function",
     "props": Object {
-      "backButton": Object {
-        "className": "discovery",
-      },
       "children": Array [
-        false,
+        <main
+          className="discovery-page no-padding page with-footer"
+          role="main"
+        >
+          <Connect(Footer)
+            borderTop={true}
+          />
+        </main>,
         <Loader
           haserror={false}
           isempty={false}
           isloading={true}
         />,
       ],
-      "footer": [Function],
-      "handleDataRequest": [Function],
-      "name": "discovery",
-      "noPadding": true,
     },
     "ref": null,
     "rendered": Array [
-      false,
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            false,
+            false,
+            <Connect(Footer)
+              borderTop={true}
+            />,
+          ],
+          "className": "discovery-page no-padding page with-footer",
+          "role": "main",
+        },
+        "ref": null,
+        "rendered": Array [
+          false,
+          false,
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "borderTop": true,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+        ],
+        "type": "main",
+      },
       Object {
         "instance": null,
         "key": undefined,
@@ -56,7 +123,7 @@ ShallowWrapper {
         "type": [Function],
       },
     ],
-    "type": [Function],
+    "type": Symbol(react.fragment),
   },
   Symbol(enzyme.__nodes__): Array [
     Object {
@@ -64,25 +131,57 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "function",
       "props": Object {
-        "backButton": Object {
-          "className": "discovery",
-        },
         "children": Array [
-          false,
+          <main
+            className="discovery-page no-padding page with-footer"
+            role="main"
+          >
+            <Connect(Footer)
+              borderTop={true}
+            />
+          </main>,
           <Loader
             haserror={false}
             isempty={false}
             isloading={true}
           />,
         ],
-        "footer": [Function],
-        "handleDataRequest": [Function],
-        "name": "discovery",
-        "noPadding": true,
       },
       "ref": null,
       "rendered": Array [
-        false,
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              false,
+              false,
+              <Connect(Footer)
+                borderTop={true}
+              />,
+            ],
+            "className": "discovery-page no-padding page with-footer",
+            "role": "main",
+          },
+          "ref": null,
+          "rendered": Array [
+            false,
+            false,
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "borderTop": true,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+          ],
+          "type": "main",
+        },
         Object {
           "instance": null,
           "key": undefined,
@@ -97,7 +196,7 @@ ShallowWrapper {
           "type": [Function],
         },
       ],
-      "type": [Function],
+      "type": Symbol(react.fragment),
     },
   ],
   Symbol(enzyme.__options__): Object {

--- a/src/components/pages/discovery/tests/index.spec.js
+++ b/src/components/pages/discovery/tests/index.spec.js
@@ -3,16 +3,17 @@ import { shallow } from 'enzyme'
 
 import { RawDiscoveryPage } from '../index'
 
-const dispatchMock = jest.fn()
-
 describe('src | components | pages | discovery | Index | DiscoveryPage', () => {
   describe('snapshot', () => {
     it('should match snapshot', () => {
       // given
       const props = {
         backButton: true,
-        dispatch: dispatchMock,
+        dispatch: jest.fn(),
         history: {},
+        location: {
+          search: '',
+        },
         match: {},
       }
 
@@ -30,8 +31,11 @@ describe('src | components | pages | discovery | Index | DiscoveryPage', () => 
         // given
         const props = {
           backButton: true,
-          dispatch: dispatchMock,
+          dispatch: jest.fn(),
           history: {},
+          location: {
+            search: '',
+          },
           match: {},
         }
 
@@ -52,16 +56,19 @@ describe('src | components | pages | discovery | Index | DiscoveryPage', () => 
       describe('One case', () => {
         it('should first dispatch requestData when  Main component is rendered', () => {
           // given
+          const dispatchMock = jest.fn()
           const props = {
             backButton: true,
             dispatch: dispatchMock,
             history: {},
+            location: {
+              search: '',
+            },
             match: {},
           }
 
           // when
-          const wrapper = shallow(<RawDiscoveryPage {...props} />)
-          wrapper.instance().handleDataRequest()
+          shallow(<RawDiscoveryPage {...props} />)
           const expectedRequest = {
             config: {},
             method: 'PUT',


### PR DESCRIPTION
Le composant Main avait le vilain defaut de lancer deux requetes PUT recommendations à la suite en moins de qqes ms, ce qui etait pas bien compris par le backend (car ca causait le fait de creer en doublon des cartes reco tutos).

Du coup là... en passant, pour eviter que DiscoveryPage n'appelle pas en doublon PUT recommendations, c'etait plus simple de lui faire enlever le composant Main qu'on doit enlever d'ailleurs partout quand on peut:).