### PR TITLE
choose node_modules/.bin/testcafe instead of node_modules/testcafe/testcafe.js script

### DIFF
--- a/scripts/pc.js
+++ b/scripts/pc.js
@@ -26,6 +26,6 @@ const NODE_ENV = environment === 'local' ? 'development' : environment
 
 if (testcafe) {
   const debugOption = program.environment === 'local' ? '-d' : ''
-  const command = `NODE_ENV=${NODE_ENV} ./node_modules/testcafe/bin/testcafe.js ${browser} ${debugOption} testcafe/${file}`
+  const command = `NODE_ENV=${NODE_ENV} ./node_modules/.bin/testcafe ${browser} ${debugOption} testcafe/${file}`
   childProcess.execSync(command, { stdio: [0, 1, 2] })
 }


### PR DESCRIPTION
pour eviter le problème de devoir faire un chmod de node_modules/testcafe/testcafe.js quand on lance la commande pc test-cafe-webapp en dev.