### PR TITLE
Pc 1329 fix filters reinitialization

### DIFF
--- a/src/components/pages/SearchPageContent.js
+++ b/src/components/pages/SearchPageContent.js
@@ -97,7 +97,10 @@ class SearchPageContent extends PureComponent {
       {
         categories: null,
         date: null,
+        distance: null,
         jours: null,
+        latitude: null,
+        longitude: null,
         'mots-cles': null,
         page: null,
       },

--- a/src/components/pages/search/FilterByDates.js
+++ b/src/components/pages/search/FilterByDates.js
@@ -9,20 +9,36 @@ import { DatePickerField } from '../../forms/inputs'
 class FilterByDates extends PureComponent {
   constructor(props) {
     super(props)
-    this.datepickerPopper = React.createRef()
     this.state = {
       pickedDate: null,
     }
+    this.datepickerPopper = React.createRef()
+  }
+
+  componentDidUpdate() {
+    const { initialDateParams, filterState } = this.props
+    if (
+      (initialDateParams && filterState.params.date === undefined) ||
+      (initialDateParams && filterState.params.date === null)
+    ) {
+      this.setPickedDate(null)
+    }
+  }
+
+  setPickedDate = value => {
+    this.setState({
+      pickedDate: value,
+    })
   }
 
   onChange = day => {
-    this.setState({ pickedDate: null })
+    this.setPickedDate(null)
     const { filterActions, filterState } = this.props
-
     const pickedDaysInQuery = decodeURI(filterState.params.jours || '')
     const isdayAlreadyChecked = pickedDaysInQuery.includes(day)
     let callback
     const pickedDaysInQueryLenght = get(pickedDaysInQuery, 'length')
+
     // change callback value
     if (pickedDaysInQueryLenght === 0) {
       // Case 1
@@ -49,18 +65,18 @@ class FilterByDates extends PureComponent {
     const { filterActions } = this.props
     const formatedDate = (date && date.toISOString()) || null
     filterActions.change({ date: formatedDate, jours: null })
-    this.setState({ pickedDate: date })
+    this.setPickedDate(date)
   }
 
-  isDaysChecked = (pickedDate, pickedDaysInQuery, inputValue) =>
-    pickedDate !== null && inputValue === '0-1'
+  isDaysChecked = (date, pickedDaysInQuery, inputValue) =>
+    date !== null && inputValue === '0-1'
       ? false
       : pickedDaysInQuery.includes(inputValue)
 
   render() {
+    const { pickedDate } = this.state
     const { filterState, minDate, title } = this.props
     const pickedDaysInQuery = decodeURI(filterState.params.jours || '')
-    const { pickedDate } = this.state
 
     return (
       <div id="filter-by-dates" className="pt18">
@@ -123,6 +139,7 @@ FilterByDates.defaultProps = {
 FilterByDates.propTypes = {
   filterActions: PropTypes.object.isRequired,
   filterState: PropTypes.object.isRequired,
+  initialDateParams: PropTypes.bool.isRequired,
   minDate: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   title: PropTypes.string.isRequired,
 }

--- a/src/components/pages/search/FilterByDistance.js
+++ b/src/components/pages/search/FilterByDistance.js
@@ -51,6 +51,8 @@ class FilterByDistance extends PureComponent {
 
     const distanceValue = filterState.params.distance || 20000
 
+    const isSelected = value => (distanceValue === value ? 'selected' : null)
+
     return (
       <div key={distanceKey} id="filter-by-distance" className="pt18">
         <h2 className="fs15 is-italic is-medium is-uppercase text-center mb12">
@@ -64,7 +66,7 @@ class FilterByDistance extends PureComponent {
             name="distance"
           >
             {options.map(({ label, value }) => (
-              <option key={value} value={value}>
+              <option key={value} value={value} selected={isSelected(value)}>
                 {label}
               </option>
             ))}

--- a/src/components/pages/search/SearchFilter.js
+++ b/src/components/pages/search/SearchFilter.js
@@ -37,6 +37,7 @@ class SearchFilter extends Component {
 
     this.state = {
       filterParamsMatchingQueryParams: false,
+      initialDateParams: true,
       params: Object.assign({}, queryParams),
     }
     this.filterActions = {
@@ -65,7 +66,7 @@ class SearchFilter extends Component {
   }
 
   onFilterClick = () => {
-    const { dispatch, onKeywordsEraseClick, query } = this.props
+    const { dispatch, query } = this.props
     const { filterParamsMatchingQueryParams, params } = this.state
 
     if (filterParamsMatchingQueryParams) {
@@ -74,26 +75,23 @@ class SearchFilter extends Component {
 
     params.page = null
 
-    if (onKeywordsEraseClick) {
-      onKeywordsEraseClick()
-    }
-
     query.change(params, { pathname: '/recherche/resultats' })
+    this.setState({
+      initialDateParams: false,
+    })
   }
 
   onResetClick = () => {
     const { dispatch, query } = this.props
-    const queryParams = query.parse()
-
     dispatch(assignData({ recommendations: [] }))
-
-    const filterParamsMatchingQueryParams = getFirstChangingKey(
-      queryParams,
-      INITIAL_FILTER_PARAMS
-    )
-
-    this.setState({ filterParamsMatchingQueryParams })
-
+    this.setState({
+      initialDateParams: true,
+      params: {
+        date: null,
+        distance: null,
+        jours: null,
+      },
+    })
     query.change(INITIAL_FILTER_PARAMS, {
       pathname: '/recherche/resultats',
     })
@@ -151,6 +149,7 @@ class SearchFilter extends Component {
 
   render() {
     const { isVisible } = this.props
+    const { initialDateParams } = this.state
     return (
       <div className="is-relative is-clipped">
         <Transition in={isVisible} timeout={transitionDelay}>
@@ -163,6 +162,7 @@ class SearchFilter extends Component {
               <FilterByDates
                 filterActions={this.filterActions}
                 filterState={this.state}
+                initialDateParams={initialDateParams}
                 title="QUAND"
               />
               <FilterByDistance
@@ -210,7 +210,6 @@ SearchFilter.propTypes = {
   dispatch: PropTypes.func.isRequired,
   isVisible: PropTypes.bool.isRequired,
   location: PropTypes.object.isRequired,
-  onKeywordsEraseClick: PropTypes.func.isRequired,
   query: PropTypes.object.isRequired,
 }
 

--- a/src/components/pages/search/tests/FilterByDates.spec.js
+++ b/src/components/pages/search/tests/FilterByDates.spec.js
@@ -4,6 +4,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 
 import FilterByDates from '../FilterByDates'
+import { DatePickerField } from '../../../forms/inputs'
 
 const filterActionsAddMock = jest.fn()
 const filterActionsChangeMock = jest.fn()
@@ -28,6 +29,7 @@ const initialProps = {
       orderBy: 'offer.id+desc',
     },
   },
+  initialDateParams: false,
   title: 'Fake title',
 }
 
@@ -101,6 +103,7 @@ describe('src | components | pages | search | FilterByDates', () => {
                 orderBy: 'offer.id+desc',
               },
             },
+            initialDateParams: false,
             title: 'Fake title',
           }
           const pickedDate = moment('12/12/2034', 'DD/MM/YYYY')
@@ -135,6 +138,7 @@ describe('src | components | pages | search | FilterByDates', () => {
                 orderBy: 'offer.id+desc',
               },
             },
+            initialDateParams: false,
             title: 'Fake title',
           }
 
@@ -152,7 +156,7 @@ describe('src | components | pages | search | FilterByDates', () => {
       })
     })
     describe('OnChange', () => {
-      describe('When a date is already selected with calendar', () => {
+      describe('When a date is already selected with calendar and user pick one of the checkboxes', () => {
         it('it should set picked date from calendar to null', () => {
           // given
           const props = {
@@ -170,17 +174,19 @@ describe('src | components | pages | search | FilterByDates', () => {
                 orderBy: 'offer.id+desc',
               },
             },
+            initialDateParams: false,
             title: 'Fake title',
           }
-
           // when
           const wrapper = shallow(<FilterByDates {...props} />)
+          const datePicker = wrapper.find(DatePickerField).props()
           wrapper
             .find('input')
             .at(1)
             .simulate('change')
 
           // then
+          expect(datePicker.selected).toEqual(null)
           expect(wrapper.state()).toEqual({ pickedDate: null })
         })
       })

--- a/src/components/pages/search/tests/SearchFilter.spec.js
+++ b/src/components/pages/search/tests/SearchFilter.spec.js
@@ -11,6 +11,7 @@ import REDUX_STATE from '../../../../mocks/reduxState'
 
 const dispatchMock = jest.fn()
 const queryChangeMock = jest.fn()
+const queryClearMock = jest.fn()
 
 const middlewares = []
 const mockStore = configureStore(middlewares)
@@ -100,6 +101,8 @@ describe('src | components | pages | search | SearchFilter', () => {
           query: {
             change: queryChangeMock,
             parse: () => ({
+              categories: 'Lire, Regarder',
+              distance: 50,
               jours: '0-1',
               page: '1',
             }),
@@ -111,11 +114,18 @@ describe('src | components | pages | search | SearchFilter', () => {
 
         // when
         wrapper.instance().onResetClick()
-        const updatedFormState = wrapper.state(
-          'filterParamsMatchingQueryParams'
-        )
+        const updatedFormState = wrapper.state()
+        const expected = {
+          filterParamsMatchingQueryParams: false,
+          initialDateParams: true,
+          params: {
+            date: null,
+            distance: null,
+            jours: null,
+          },
+        }
 
-        expect(updatedFormState).toEqual('jours')
+        expect(updatedFormState).toEqual(expected)
 
         expect(queryChangeMock).toHaveBeenCalledWith(INITIAL_FILTER_PARAMS, {
           pathname: '/recherche/resultats',
@@ -133,6 +143,7 @@ describe('src | components | pages | search | SearchFilter', () => {
           onKeywordsEraseClick: jest.fn(),
           query: {
             change: queryChangeMock,
+            clear: queryClearMock,
             parse: () => ({
               jours: '0-1',
               page: '1',
@@ -154,7 +165,6 @@ describe('src | components | pages | search | SearchFilter', () => {
         expect(queryChangeMock).toHaveBeenCalledWith(currentQuery, {
           pathname: '/recherche/resultats',
         })
-
         expect(updatedFormState).toEqual(false)
       })
     })

--- a/src/components/pages/search/tests/__snapshots__/FilterByDates.spec.js.snap
+++ b/src/components/pages/search/tests/__snapshots__/FilterByDates.spec.js.snap
@@ -26,6 +26,7 @@ ShallowWrapper {
         },
       }
     }
+    initialDateParams={false}
     minDate="Dec 10th 18"
     title="Fake title"
   />,

--- a/src/components/pages/tests/SearchPageContent.spec.js
+++ b/src/components/pages/tests/SearchPageContent.spec.js
@@ -253,7 +253,10 @@ describe('src | components | pages | SearchPageContent', () => {
           const argument1 = {
             categories: null,
             date: null,
+            distance: null,
             jours: null,
+            latitude: null,
+            longitude: null,
             'mots-cles': null,
             page: null,
           }


### PR DESCRIPTION
Solution à challenger ! 
Il fallait informer le filter by dates du fait que la date a été réinitialisée car le date picker n'avait pas accès à cette information.