### PR TITLE
pc-1318 masquer les offres d'activations de types thing

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "is-absolute-url": "^2.1.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
-    "lodash.difference": "^4.5.0",
     "lodash.find": "^4.6.0",
     "lodash.flatten": "^4.4.0",
     "lodash.get": "^4.4.2",

--- a/src/components/pages/my-bookings/connect.js
+++ b/src/components/pages/my-bookings/connect.js
@@ -1,0 +1,14 @@
+import {
+  selectSoonBookings,
+  selectOtherBookings,
+  selectRecommendations,
+} from '../../../selectors'
+
+export const mapStateToProps = state => {
+  const recommendations = selectRecommendations(state)
+  const otherBookings = selectOtherBookings(state)
+  const soonBookings = selectSoonBookings(state)
+  return { otherBookings, recommendations, soonBookings }
+}
+
+export default mapStateToProps

--- a/src/components/pages/my-bookings/index.js
+++ b/src/components/pages/my-bookings/index.js
@@ -7,19 +7,15 @@ import { connect } from 'react-redux'
 import { bindActionCreators, compose } from 'redux'
 import get from 'lodash.get'
 
-import { ROOT_PATH } from '../../utils/config'
-import MyBookingItem from './my-bookings/MyBookingItem'
-import NoBookingView from './my-bookings/NoBookingView'
-import {
-  selectSoonBookings,
-  selectOtherBookings,
-  selectRecommendations,
-} from '../../selectors'
-import Loader from '../layout/Loader'
-import PageHeader from '../layout/PageHeader'
-import { toggleMainMenu } from '../../reducers/menu'
-import NavigationFooter from '../layout/NavigationFooter'
-import { bookingNormalizer } from '../../utils/normalizers'
+import { ROOT_PATH } from '../../../utils/config'
+import MyBookingItem from './MyBookingItem'
+import NoBookingView from './NoBookingView'
+import Loader from '../../layout/Loader'
+import PageHeader from '../../layout/PageHeader'
+import { toggleMainMenu } from '../../../reducers/menu'
+import NavigationFooter from '../../layout/NavigationFooter'
+import { bookingNormalizer } from '../../../utils/normalizers'
+import { mapStateToProps } from './connect'
 
 const renderBookingList = items => (
   <ul className="bookings">
@@ -120,13 +116,6 @@ MyBookingsPage.propTypes = {
   dispatch: PropTypes.func.isRequired,
   otherBookings: PropTypes.array.isRequired,
   soonBookings: PropTypes.array.isRequired,
-}
-
-const mapStateToProps = state => {
-  const recommendations = selectRecommendations(state)
-  const otherBookings = selectOtherBookings(state)
-  const soonBookings = selectSoonBookings(state)
-  return { otherBookings, recommendations, soonBookings }
 }
 
 export default compose(

--- a/src/selectors/selectBookings.js
+++ b/src/selectors/selectBookings.js
@@ -1,47 +1,67 @@
 import get from 'lodash.get'
 import moment from 'moment'
-import difference from 'lodash.difference'
 import { createSelector } from 'reselect'
 
-const filterBookingsActivationOfTypeThing = bookingobj => {
+export const filterBookingsActivationOfTypeThing = bookingobj => {
   const offer = get(bookingobj, 'stock.resolvedOffer')
+  if (!offer) return false
   const offerType = get(offer, 'eventOrThing.type')
+  if (!offerType) return false
   const isActivationType = offerType === 'EventType.ACTIVATION'
   if (!isActivationType) return true
   const offerThingId = get(offer, 'thingId')
   return !offerThingId
 }
 
+export const filterBookingsInLessThanTwoDays = (
+  allBookings,
+  momentNowMock = null
+) => {
+  const twoDaysFromNow = (momentNowMock || moment()).add(2, 'days')
+  const filtered = allBookings
+    .filter(booking => {
+      const date = get(booking, 'stock.eventOccurrence.beginningDatetime')
+      if (!date) return false
+      return moment(date).isSameOrBefore(twoDaysFromNow)
+    })
+    .filter(filterBookingsActivationOfTypeThing)
+  return filtered
+}
+
+export const filterBookingsInMoreThanTwoDays = (allBookings, momentNowMock) => {
+  const twoDaysFromNow = (momentNowMock || moment()).add(2, 'days')
+  const filtered = allBookings
+    .filter(booking => {
+      const date = get(booking, 'stock.eventOccurrence.beginningDatetime')
+      if (!date) return false
+      return moment(date).isAfter(twoDaysFromNow)
+    })
+    .filter(filterBookingsActivationOfTypeThing)
+  return filtered
+}
+
+export const removePastBookings = (allbookings, momentNowMock = null) => {
+  const now = momentNowMock || moment()
+  return allbookings.filter(booking => {
+    const date = get(booking, 'stock.eventOccurrence.beginningDatetime')
+    if (!date) return false
+    return moment(date).isSameOrAfter(now)
+  })
+}
+
 export const selectBookings = createSelector(
   state => state.data.bookings,
-  allBookings => allBookings
+  removePastBookings
 )
 
 export const selectSoonBookings = createSelector(
-  // select all bookings
   selectBookings,
-  allBookings => {
-    const twoDaysFromNow = moment().subtract(2, 'days')
-    const filtered = allBookings
-      .filter(booking => {
-        const date = get(booking, 'stock.eventOccurrence.beginningDatetime')
-        if (!date) return false
-        return moment(date).isSameOrBefore(twoDaysFromNow)
-      })
-      .filter(filterBookingsActivationOfTypeThing)
-    return filtered
-  }
+  filterBookingsInLessThanTwoDays
 )
 
 export const selectOtherBookings = createSelector(
   selectBookings,
-  selectSoonBookings,
-  (allBookings, soonBookings) => {
-    const filtered = difference(allBookings, soonBookings).filter(
-      filterBookingsActivationOfTypeThing
-    )
-    return filtered
-  }
+  filterBookingsInMoreThanTwoDays
 )
 
 export const selectBookingById = createSelector(

--- a/src/selectors/tests/data/selectBookings.js
+++ b/src/selectors/tests/data/selectBookings.js
@@ -1,0 +1,71 @@
+const resolvedOffer = {
+  resolvedOffer: {
+    eventOrThing: {
+      type: 'EventType.ACTIVATION',
+    },
+    offerId: 1234,
+  },
+}
+
+const AllBookingsDataset = now => [
+  { debugid: 'not a valid boking' },
+  { debugid: 'not a valid stock', stock: {} },
+  {
+    stock: {
+      eventOccurrence: {
+        debugid: 'not-a-valid-eventOccurrence',
+      },
+      ...resolvedOffer,
+    },
+  },
+  {
+    stock: {
+      eventOccurrence: {
+        beginningDatetime: now.clone().subtract(1, 'days'),
+        debugid: 'yesterday',
+      },
+      ...resolvedOffer,
+    },
+  },
+  {
+    stock: {
+      eventOccurrence: {
+        beginningDatetime: now.clone().add(4, 'days'),
+        debugid: 'in-4-days',
+      },
+      ...resolvedOffer,
+    },
+  },
+  {
+    stock: {
+      eventOccurrence: {
+        beginningDatetime: now
+          .clone()
+          .add(2, 'days')
+          .add(1, 'seconds'),
+        debugid: 'in-2-days-and-1-seconds',
+      },
+      ...resolvedOffer,
+    },
+  },
+  {
+    stock: {
+      eventOccurrence: {
+        beginningDatetime: now.clone().add(2, 'days'),
+        debugid: 'in-exact-2-days',
+      },
+      ...resolvedOffer,
+    },
+  },
+  {
+    stock: {
+      eventOccurrence: {
+        beginningDatetime: now.clone().add(1, 'days'),
+        debugid: 'tomorrow',
+      },
+      ...resolvedOffer,
+    },
+  },
+]
+
+export default AllBookingsDataset

--- a/src/selectors/tests/selectBookings.spec.js
+++ b/src/selectors/tests/selectBookings.spec.js
@@ -1,18 +1,176 @@
-import { selectBookingById } from '../selectBookings'
+// jest --env=jsdom ./src/selectors/tests/selectBookings --watch
+import moment from 'moment'
+import get from 'lodash.get'
 
-describe('src | selectors | selectBookings | selectBookingById', () => {
-  it('should return booking matching id', () => {
-    // given
-    const state = {
-      data: {
-        bookings: [{ id: 'foo' }, { id: 'bar' }, { id: 'baz' }],
-      },
-    }
-    // When
-    const result = selectBookingById(state, 'bar')
-    // Then
-    expect(result).toBeDefined()
-    expect(result).toEqual({ id: 'bar' })
-    expect(result).toBe(state.data.bookings[1])
+import AllBookingsDataset from './data/selectBookings'
+import {
+  filterBookingsActivationOfTypeThing,
+  filterBookingsInLessThanTwoDays,
+  removePastBookings,
+  filterBookingsInMoreThanTwoDays,
+  selectBookingById,
+} from '../selectBookings'
+
+describe('src | selectors | selectBookings', () => {
+  describe(' selectBookingById', () => {
+    it('should return booking matching id', () => {
+      // given
+      const state = {
+        data: {
+          bookings: [{ id: 'foo' }, { id: 'bar' }, { id: 'baz' }],
+        },
+      }
+      // When
+      const result = selectBookingById(state, 'bar')
+      // Then
+      expect(result).toBeDefined()
+      expect(result).toEqual({ id: 'bar' })
+      expect(result).toBe(state.data.bookings[1])
+    })
+  })
+  describe('filterBookingsActivationOfTypeThing', () => {
+    it('returns false, missing stock', () => {
+      // given
+      const booking = {}
+      // when
+      const result = filterBookingsActivationOfTypeThing(booking)
+      // then
+      const expected = false
+      expect(result).toStrictEqual(expected)
+    })
+    it('returns false, missing stock.resolvedOffer', () => {
+      // given
+      const booking = { stock: {} }
+      // when
+      const result = filterBookingsActivationOfTypeThing(booking)
+      // then
+      const expected = false
+      expect(result).toStrictEqual(expected)
+    })
+    it('returns false, missing stock.resolvedOffer.eventOrThing', () => {
+      // given
+      const booking = { stock: { resolvedOffer: {} } }
+      // when
+      const result = filterBookingsActivationOfTypeThing(booking)
+      // then
+      const expected = false
+      expect(result).toStrictEqual(expected)
+    })
+    it('returns false, missing stock.resolvedOffer.eventOrThing.type', () => {
+      // given
+      const booking = { stock: { resolvedOffer: { eventOrThing: {} } } }
+      // when
+      const result = filterBookingsActivationOfTypeThing(booking)
+      // then
+      const expected = false
+      expect(result).toStrictEqual(expected)
+    })
+    it('returns true, type is not an activation type', () => {
+      const booking = {
+        stock: {
+          resolvedOffer: { eventOrThing: { type: 'EventType.ANY' } },
+        },
+      }
+      // when
+      const result = filterBookingsActivationOfTypeThing(booking)
+      // then
+      const expected = true
+      expect(result).toStrictEqual(expected)
+    })
+    it('returns false, is an activation type and a thing/numeric offer', () => {
+      // given
+      const booking = {
+        stock: {
+          resolvedOffer: {
+            eventOrThing: {
+              type: 'EventType.ACTIVATION',
+            },
+            offerId: null,
+            thingId: 1234,
+          },
+        },
+      }
+      // when
+      const result = filterBookingsActivationOfTypeThing(booking)
+      // then
+      const expected = false
+      expect(result).toStrictEqual(expected)
+    })
+    it('returns true, is an activation type and not a thing/numeric offer', () => {
+      // given
+      const booking = {
+        stock: {
+          resolvedOffer: {
+            eventOrThing: {
+              type: 'EventType.ACTIVATION',
+            },
+            offerId: 1234,
+            thingId: null,
+          },
+        },
+      }
+      // when
+      const result = filterBookingsActivationOfTypeThing(booking)
+      // then
+      const expected = true
+      expect(result).toStrictEqual(expected)
+    })
+  })
+  describe('filterBookingsInLessThanTwoDays', () => {
+    it('returns an array of bookings with beginningDatetime <= 2 days', () => {
+      // given
+      const momentNowMock = moment()
+      const allbookings = AllBookingsDataset(momentNowMock)
+      // when
+      const result = filterBookingsInLessThanTwoDays(allbookings, momentNowMock)
+      // then
+      const expected = allbookings.filter(o => {
+        const debugid = get(o, 'stock.eventOccurrence.debugid')
+        return (
+          debugid === 'yesterday' ||
+          debugid === 'in-exact-2-days' ||
+          debugid === 'tomorrow'
+        )
+      })
+      expect(result).toHaveLength(3)
+      expect(result).toStrictEqual(expected)
+    })
+  })
+  describe('removePastBookings', () => {
+    it('returns all bookings excepts >= today hh:mm:s', () => {
+      // given
+      const momentNowMock = moment()
+      const allbookings = AllBookingsDataset(momentNowMock)
+      // when
+      const result = removePastBookings(allbookings, momentNowMock)
+      // then
+      const expected = allbookings.filter(o => {
+        const debugid = get(o, 'stock.eventOccurrence.debugid')
+        return (
+          debugid === 'in-4-days' ||
+          debugid === 'in-2-days-and-1-seconds' ||
+          debugid === 'in-exact-2-days' ||
+          debugid === 'tomorrow'
+        )
+      })
+      expect(result).toHaveLength(4)
+      expect(result).toStrictEqual(expected)
+    })
+  })
+  describe('filterBookingsInMoreThanTwoDays', () => {
+    it('returns all bookings excepts >= today hh:mm:s', () => {
+      // given
+      const momentNowMock = moment()
+      const allbookings = AllBookingsDataset(momentNowMock.clone())
+      // when
+      const result = filterBookingsInMoreThanTwoDays(allbookings, momentNowMock)
+      // then
+      const expected = allbookings.filter(o => {
+        const debugid = get(o, 'stock.eventOccurrence.debugid')
+        return debugid === 'in-4-days' || debugid === 'in-2-days-and-1-seconds'
+      })
+      expect(result).toHaveLength(2)
+      expect(result).toStrictEqual(expected)
+    })
   })
 })

--- a/src/utils/routes.js
+++ b/src/utils/routes.js
@@ -3,7 +3,7 @@ import { Redirect } from 'react-router-dom'
 
 import ActivationPage from '../components/pages/activation'
 import BetaPage from '../components/pages/BetaPage'
-import MyBookingsPage from '../components/pages/MyBookingsPage'
+import MyBookingsPage from '../components/pages/my-bookings'
 import DiscoveryPage from '../components/pages/discovery'
 import FavoritesPage from '../components/pages/FavoritesPage'
 import ForgotPasswordPage from '../components/pages/ForgotPasswordPage'

--- a/src/utils/tests/routes-utils.spec.js
+++ b/src/utils/tests/routes-utils.spec.js
@@ -4,7 +4,7 @@ import { getReactRoutes, getMainMenuItems } from '../routes-utils'
 import routes from '../routes'
 
 import SearchPage from '../../components/pages/SearchPage'
-import MyBookingsPage from '../../components/pages/MyBookingsPage'
+import MyBookingsPage from '../../components/pages/my-bookings'
 import DiscoveryPage from '../../components/pages/discovery'
 import FavoritesPage from '../../components/pages/FavoritesPage'
 


### PR DESCRIPTION
- par defaut a la creation du compte user, on cree automatiquement une offre de reservation de type numerique
- il faut masquer cette offre afin que l'user n'est pas acces a la contremarque
- j'ai bougé le fichier MyBookingsPage dans le fichier my-bookings/index.js et mis le mapStateToProps dans le fichier connect

[Ticker JIRA](https://passculture.atlassian.net/browse/PC-1318)