### PR TITLE
PC-1464 fix de l'attribut rel ne doit pas etre un boolean

### DIFF
--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -48,7 +48,7 @@ export class MenuItemContent extends React.PureComponent {
         disabled={disabled}
         href={href}
         key={href}
-        rel={target === '_blank' && 'noopener noreferer'}
+        rel={(target === '_blank' && 'noopener noreferer') || null}
         target={target}
       >
         {renderLinkContent(icon, title)}

--- a/src/components/menu/tests/MenuItem.spec.js
+++ b/src/components/menu/tests/MenuItem.spec.js
@@ -31,11 +31,25 @@ describe('src | components | menu | MenuItemContent', () => {
 
 describe('src | components | menu | MenuItem', () => {
   describe('snapshot', () => {
-    it('should match snapshot', () => {
+    it('should match snapshot with in-app link', () => {
       // given
       const props = {
         ...routerProps,
         item: { path: '/decouverte' },
+      }
+
+      // when
+      const wrapper = shallow(<MenuItem {...props} />)
+
+      // then
+      expect(wrapper).toBeDefined()
+      expect(wrapper).toMatchSnapshot()
+    })
+    it('should match snapshot with external link', () => {
+      // given
+      const props = {
+        ...routerProps,
+        item: { href: 'http://www.external.link', target: '_blank' },
       }
 
       // when

--- a/src/components/menu/tests/__snapshots__/MenuItem.spec.js.snap
+++ b/src/components/menu/tests/__snapshots__/MenuItem.spec.js.snap
@@ -1,6 +1,74 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | menu | MenuItem snapshot should match snapshot 1`] = `
+exports[`src | components | menu | MenuItem snapshot should match snapshot with external link 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <withRouter(MenuItemContent)
+    item={
+      Object {
+        "href": "http://www.external.link",
+        "target": "_blank",
+      }
+    }
+    location={
+      Object {
+        "pathname": "/decouverte",
+      }
+    }
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "class",
+    "props": Object {
+      "children": [Function],
+    },
+    "ref": null,
+    "rendered": [Function],
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "children": [Function],
+      },
+      "ref": null,
+      "rendered": [Function],
+      "type": [Function],
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getDerivedStateFromProps": true,
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`src | components | menu | MenuItem snapshot should match snapshot with in-app link 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <withRouter(MenuItemContent)


### PR DESCRIPTION
Le ternaire renvoyait un boolean pour l'attribut `rel`, qui levait une exception React en cas de `target='_blank'`
Fallait le savoir :)