### PR TITLE
Add sleep before apt-get in circle-ci config to avoid error on apt lock file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,11 @@ jobs:
             cd pass-culture-main
             rm -rf shared
             git clone https://github.com/betagouv/pass-culture-api.git api
+            sudo lsof /var/lib/apt/lists/lock
+            while pgrep apt-get >/dev/null 2>&1 ; do
+            echo "Waiting for apt ..."
+            sleep 1
+            done
             curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
             echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             sudo lsof /var/lib/apt/lists/lock
             while pgrep apt-get >/dev/null 2>&1 ; do
             echo "Waiting for apt ..."
-            sleep 1
+            sleep 2
             done
             curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -


### PR DESCRIPTION
cf. https://discuss.circleci.com/t/cannot-install-php-7-1-on-machine-because-of-locked-var-lib-dpkg-lock-file/24639/21