### PR TITLE
(pC-50) change webapp signup route

### DIFF
--- a/src/components/pages/SignupPage.js
+++ b/src/components/pages/SignupPage.js
@@ -8,7 +8,7 @@ import { NavLink } from 'react-router-dom'
 import { withRedirectToDiscoveryWhenAlreadyAuthenticated } from '../hocs'
 import Main from '../layout/Main'
 
-class SignupPage extends React.PureComponent {
+export class RawSignupPage extends React.PureComponent {
   constructor() {
     super()
     this.state = { $footer: null }
@@ -43,7 +43,7 @@ class SignupPage extends React.PureComponent {
           </h2>
           <Form
             name="user"
-            action="/users/signup"
+            action="/users/signup/webapp"
             layout="vertical"
             handleSuccessNotification={null}
             handleSuccessRedirect={() => '/decouverte'}
@@ -119,4 +119,4 @@ class SignupPage extends React.PureComponent {
   }
 }
 
-export default withRedirectToDiscoveryWhenAlreadyAuthenticated(SignupPage)
+export default withRedirectToDiscoveryWhenAlreadyAuthenticated(RawSignupPage)

--- a/src/components/pages/tests/SignupPage.spec.js
+++ b/src/components/pages/tests/SignupPage.spec.js
@@ -1,4 +1,3 @@
-// jest --env=jsdom ./src/components/pages/tests/SignupPage --watch
 import { mount } from 'enzyme'
 import { createBrowserHistory } from 'history'
 import React from 'react'
@@ -21,7 +20,7 @@ jest.mock('redux-saga-data', () => {
 })
 
 describe('src | components | pages | SignupPage', () => {
-  it('should call users/signup/webapp', done => {
+  it('should call users/signup/webapp', () => {
     // given
     fetch.mockResponse(JSON.stringify({}), { status: 200 })
     const { store } = configureStore()
@@ -54,31 +53,26 @@ describe('src | components | pages | SignupPage', () => {
       .find("input[name='contact_ok']")
       .simulate('change', { target: { checked: true } })
 
-    setTimeout(() => {
-      const expectedSubConfig = {
-        apiPath: 'users/signup/webapp',
-        body: values,
-        method: 'POST',
-        name: 'user',
-        normalizer: null,
-      }
-      // when
-      const submitButton = wrapper.find('button[name="user"]')
+    const expectedSubConfig = {
+      apiPath: 'users/signup/webapp',
+      body: values,
+      method: 'POST',
+      name: 'user',
+      normalizer: null,
+    }
+    // when
+    const submitButton = wrapper.find('button[name="user"]')
 
-      // then
-      expect(submitButton.props().disabled).toEqual(false)
+    // then
+    expect(submitButton.props().disabled).toEqual(false)
 
-      // when
-      submitButton.simulate('click')
+    // when
+    submitButton.simulate('click')
 
-      // then
-      const receivedConfig = mockRequestDataCatch.mock.calls[0][0]
-      Object.keys(expectedSubConfig).forEach(key =>
-        expect(receivedConfig[key]).toEqual(expectedSubConfig[key])
-      )
-
-      // done
-      done()
-    })
+    // then
+    const receivedConfig = mockRequestDataCatch.mock.calls[0][0]
+    Object.keys(expectedSubConfig).forEach(key =>
+      expect(receivedConfig[key]).toEqual(expectedSubConfig[key])
+    )
   })
 })

--- a/src/components/pages/tests/SignupPage.spec.js
+++ b/src/components/pages/tests/SignupPage.spec.js
@@ -1,0 +1,86 @@
+// jest --env=jsdom ./src/components/pages/tests/SignupPage --watch
+/* eslint-disable */
+import { mount } from 'enzyme'
+import { createBrowserHistory } from 'history'
+import React, { Component } from 'react'
+import { connect, Provider } from 'react-redux'
+import { Route, Router } from 'react-router-dom'
+import configureStore from 'redux-mock-store'
+
+import { RawSignupPage } from '../SignupPage'
+
+const mockStore = configureStore([])
+class RawFormCallback extends Component {
+  componentDidUpdate() {
+    const { onFormUpdate } = this.props
+    onFormUpdate()
+  }
+
+  render() {
+    return null
+  }
+}
+function mapStateToProps(state) {
+  return { form: state.form.user }
+}
+const FormCallback = connect(mapStateToProps)(RawFormCallback)
+
+describe('src | components | pages | SignupPage', () => {
+  it('should call users/signup/webapp', done => {
+    // given
+    function setInput(wrapper, key, value) {
+      wrapper
+        .find(`input[name='${key}']`)
+        .simulate('change', { target: { value } })
+    }
+    const mockDispatch = jest.fn()
+    const failFunction = jest.fn()
+    const initialState = { data: { users: [] }, form: { user: {} }, modal: {} }
+    const store = mockStore(initialState)
+    const successFunction = jest.fn()
+    const values = {
+      contact_ok: true,
+      email: 'fake@email.fr',
+      password: 'fake.P@ssw0rd',
+      publicName: 'fakePublic',
+    }
+    const props = { dispatch: mockDispatch }
+    const history = createBrowserHistory()
+    history.push('/test')
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <Route path="/test">
+            <RawSignupPage {...props} />
+            <FormCallback onFormUpdate={onFormUpdate} />
+          </Route>
+        </Router>
+      </Provider>
+    )
+    Object.keys(values).forEach(key => setInput(wrapper, key, values[key]))
+    /* eslint-disable no-use-before-define */
+    function onFormUpdate() {
+      const config = {
+        apiPath: '/users/signup/webapp',
+        body: values,
+        handleFail: failFunction,
+        handleSuccess: successFunction,
+        method: 'POST',
+      }
+      const expectedAction = {
+        config,
+        type: 'REQUEST_DATA_POST_/USERS/SIGNUP/WEBAPP',
+      }
+
+      // when
+      const submitButton = wrapper.find('button[name="user"]')
+
+      // then
+      console.log(submitButton.props())
+      expect(submitButton.props().disabled).toEqual(false)
+      submitButton.simulate('click')
+      expect(mockDispatch).toHaveBeenCalledWith(expectedAction)
+      done()
+    }
+  })
+})


### PR DESCRIPTION
@sofcalca @arnoo 
Au passage cette PR permet de montrer une façon de tester en complete mount les composants des Apps. (Ce qui peut servir à remplacer qquns de nos testcafes end to end overkill). L'idée est que si on arrive à prouver que nos tests appellent de la bonne facon les requestData... On a dans pas mal de cas prouvé le fonctionnement, car ensuite la robustesse de requestData est testée itself dans son repo et on devrait lui faire confiance comme finalement on fait confiance desormais à history.push ou dispatch qui sont des outils externes.

Les règles à suivre:
- utiliser le configureStore de l'app (et pas un mockStore)
- faire un jest.mock('redux-saga-data') pour mocker requestData
- ne pas oublier d'encapsuler le component teste dans Provider et Router, donc on pourrait limite faire un hoc withTest qui ferait se boulot, à composer devant chacun de nos objets
- il faut faire un mount pour toucher aux objets formulaires nestés (et ça sera le cas aussi pour react final form)




