### PR TITLE
[PC-1619] remove duplicates values from price range stocks

### DIFF
--- a/src/helpers/getPriceRangeFromStocks.js
+++ b/src/helpers/getPriceRangeFromStocks.js
@@ -1,10 +1,12 @@
+import uniq from 'lodash.uniq'
+
 const getPriceRangeFromStocks = stocks => {
   if (!stocks || !Array.isArray(stocks)) return []
   const filtered = stocks
     .filter(stock => stock.price || stock.price === 0)
     .filter(stock => stock.available === null || stock.available > 0)
     .map(stock => stock.price)
-  return filtered
+  return uniq(filtered)
 }
 
 export default getPriceRangeFromStocks

--- a/src/helpers/tests/getPriceRangeFromStocks.spec.js
+++ b/src/helpers/tests/getPriceRangeFromStocks.spec.js
@@ -1,3 +1,4 @@
+// $(yarn bin)/jest --env=jsdom ./src/helpers/tests/getPriceRangeFromStocks --watch
 import getPriceRangeFromStocks from '../getPriceRangeFromStocks'
 
 describe('src | helpers | getPriceRangeFromStocks', () => {
@@ -27,7 +28,7 @@ describe('src | helpers | getPriceRangeFromStocks', () => {
       expect(result).toStrictEqual(expected)
     })
     describe('when stocks exists', () => {
-      it('returns an array of prices', () => {
+      it('returns an array of prices with uniques values', () => {
         const stocks = [
           {},
           { available: 1, price: 0 },
@@ -35,6 +36,7 @@ describe('src | helpers | getPriceRangeFromStocks', () => {
           { available: 10, price: 100 },
           { available: 0, price: 22.5 },
           { available: 0, price: 0 },
+          { available: 10, price: 0 },
           { available: null, price: 56 },
         ]
         const expected = [0, 15.99, 100, 56]


### PR DESCRIPTION
Une offre pouvait retourner une array de prix [0, 0, 0, 0, 0...]
La fonction getPriceFromRangeStocks retourne désormais un array de valeurs uniques