### PR TITLE
(PC-1518) fix back to current page from menu with a search query

### DIFF
--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Icon } from 'pass-culture-shared'
-import { matchPath, withRouter } from 'react-router-dom'
+import { withRouter } from 'react-router-dom'
 
 import ReplaceLink from './ReplaceLink'
-import { getMenuItemIdFromPathname } from './utils'
+import { getMenuItemIdFromPathname, getMenuItemPathTo } from './utils'
 
 const renderLinkContent = (icon, title, styles) => (
   <React.Fragment>
@@ -14,9 +14,7 @@ const renderLinkContent = (icon, title, styles) => (
     >
       <Icon svg={`ico-${icon}`} alt="" />
     </span>
-    <span className="flex-1 is-medium">
-      {title}
-    </span>
+    <span className="flex-1 is-medium">{title}</span>
   </React.Fragment>
 )
 
@@ -24,9 +22,7 @@ export class MenuItemContent extends React.PureComponent {
   renderNavLink = opts => {
     const { item, location } = this.props
     const { title, disabled, icon, path } = item
-    const currentpath = location.pathname
-    const isactive = matchPath(currentpath, item)
-    const pathto = isactive ? currentpath.replace('/menu', '') : path
+    const pathto = getMenuItemPathTo(location, item)
     const itemid = getMenuItemIdFromPathname(pathto, 'main-menu')
     return (
       <ReplaceLink

--- a/src/components/menu/tests/MenuHeader.spec.js
+++ b/src/components/menu/tests/MenuHeader.spec.js
@@ -1,4 +1,3 @@
-// jest --env=jsdom ./src/components/menu/tests/MenuHeader --watch
 import React from 'react'
 import { shallow } from 'enzyme'
 

--- a/src/components/menu/tests/MenuItem.spec.js
+++ b/src/components/menu/tests/MenuItem.spec.js
@@ -1,4 +1,3 @@
-// jest --env=jsdom ./src/components/menu/tests/MenuItem --watch
 import React from 'react'
 import { shallow } from 'enzyme'
 

--- a/src/components/menu/tests/utils.spec.js
+++ b/src/components/menu/tests/utils.spec.js
@@ -1,29 +1,89 @@
-// jest --env=jsdom ./src/components/menu/tests/utils --watch
-import { getMenuItemIdFromPathname } from '../utils'
+import { getMenuItemIdFromPathname, getMenuItemPathTo } from '../utils'
 
 describe('src | components | menu | utils', () => {
-  it('return a string based on destination for menu item', () => {
-    // given
-    const pathto = '/base/string/path/to'
-    const prefix = 'this-is-the-prefix-for'
-    // when
-    const result = getMenuItemIdFromPathname(pathto, prefix)
-    // then
-    const expected = 'this-is-the-prefix-for-base-button'
-    expect(result).toStrictEqual(expected)
+  describe('getMenuItemIdFromPathname', () => {
+    it('is active, return location path with search query', () => {
+      const currenUrlLocation = {
+        pathname: 'base/path/to/current/page',
+        search: '?search=current_active_page_with_searchquery',
+      }
+      const item = { path: 'base/path/to/current/page' }
+      const result = getMenuItemPathTo(currenUrlLocation, item)
+
+      const expected =
+        'base/path/to/current/page?search=current_active_page_with_searchquery'
+      expect(result).toStrictEqual(expected)
+    })
+
+    it(`is not active, return item's path without current search query`, () => {
+      const currenUrlLocation = {
+        pathname: 'base/path/to/current/page',
+        search: '?search=current_active_page_with_searchquery',
+      }
+      const item = { path: 'base/path/to/another/page' }
+      const result = getMenuItemPathTo(currenUrlLocation, item)
+
+      const expected = 'base/path/to/another/page'
+      expect(result).toStrictEqual(expected)
+    })
   })
-  it('throw an error if no valid pathto arg', () => {
-    // given
-    const pathto = null
-    const prefix = 'this-is-the-prefix-for'
-    // then
-    expect(() => getMenuItemIdFromPathname(pathto, prefix)).toThrow()
-  })
-  it('throw an error if no valid prefix arg', () => {
-    // given
-    const pathto = '/base/string/path/to'
-    const prefix = ['not a string']
-    // then
-    expect(() => getMenuItemIdFromPathname(pathto, prefix)).toThrow()
+
+  describe('getMenuItemIdFromPathname', () => {
+    it('return a string based on destination for menu item', () => {
+      // given
+      const pathto = '/base/string/path/to'
+      const prefix = 'this-is-the-prefix-for'
+
+      // when
+      const result = getMenuItemIdFromPathname(pathto, prefix)
+
+      // then
+      const expected = 'this-is-the-prefix-for-base-button'
+      expect(result).toStrictEqual(expected)
+    })
+
+    it('throw an error if no valid pathto arg', () => {
+      // given
+      const pathto = null
+      const prefix = 'this-is-the-prefix-for'
+
+      // then
+      expect(() => getMenuItemIdFromPathname(pathto, prefix)).toThrow()
+    })
+
+    it('throw an error if no valid prefix arg', () => {
+      // given
+      const pathto = '/base/string/path/to'
+      const prefix = ['not a string']
+
+      // then
+      expect(() => getMenuItemIdFromPathname(pathto, prefix)).toThrow()
+    })
+
+    it('return a string based on destination for menu item when path contains a search query', () => {
+      // given
+      const pathto = '/base/string/path/to?query=any'
+      const prefix = 'this-is-the-prefix-for'
+
+      // when
+      const result = getMenuItemIdFromPathname(pathto, prefix)
+
+      // then
+      const expected = 'this-is-the-prefix-for-base-button'
+      expect(result).toStrictEqual(expected)
+    })
+
+    it('return a string based on destination for menu item when path contains a search query when route contains only one path', () => {
+      // given
+      const pathto = '/base'
+      const prefix = 'this-is-the-prefix-for'
+
+      // when
+      const result = getMenuItemIdFromPathname(pathto, prefix)
+
+      // then
+      const expected = 'this-is-the-prefix-for-base-button'
+      expect(result).toStrictEqual(expected)
+    })
   })
 })

--- a/src/components/menu/utils.js
+++ b/src/components/menu/utils.js
@@ -1,15 +1,23 @@
+import get from 'lodash.get'
+import { matchPath } from 'react-router-dom'
+
 export const getMenuItemIdFromPathname = (pathto, prefix) => {
   const isvalidpatto = pathto && typeof pathto === 'string'
   const isvalidprefix = prefix && typeof prefix === 'string'
   if (!isvalidpatto || !isvalidprefix) {
     throw new Error('Missing arguments')
   }
-  const basepath = pathto
-    .split('/')
-    .slice(1, 2)
-    .join('')
-    .toLowerCase()
+  let basepath = pathto.split('/').slice(1, 2)
+  basepath = (basepath && basepath.join('').toLowerCase()) || ''
   return `${prefix}-${basepath}-button`
 }
 
-export default getMenuItemIdFromPathname
+export const getMenuItemPathTo = (location, item) => {
+  const path = get(item, 'path')
+  const currentPath = location.pathname
+  const currentSearchQuery = location.search || ''
+  const isactive = matchPath(currentPath, item)
+  if (!isactive) return path
+  const pathto = `${currentPath.replace('/menu', '')}${currentSearchQuery}`
+  return pathto
+}


### PR DESCRIPTION
Use Case:
- ouvrir la recherche
- cliquer sur une vignette de catégorie
- ouvrir le menu principal
- cliquer sur l'item du menu "recherche"
-> L'URL doit garder le search, actuellement ce n'est pas le cas, ca casse internet

-> A tester sur d'autres pages contenant une search query