### PR TITLE
(PC-1674) afficher l'événement de la date du jour sur un booking

### DIFF
--- a/src/helpers/filterAvailableStocks.js
+++ b/src/helpers/filterAvailableStocks.js
@@ -1,19 +1,19 @@
 import moment from 'moment'
 
+const checkIfStockBookingLimitDatetimeIsAfter = now => stockItem => {
+  if (!stockItem.bookingLimitDatetime) return true
+
+  return moment(stockItem.bookingLimitDatetime).isAfter(now)
+}
+
 const filterAvailableStocks = stocks => {
-  const isvalid = stocks && Array.isArray(stocks)
-  if (!isvalid) return []
+  const isValid = stocks && Array.isArray(stocks)
+  if (!isValid) return []
+
   const now = moment()
-  // tuto n'a pas de stock
-  const filtered = stocks
-    .filter(item => item)
-    .filter(item => {
-      // item.bookingLimitDatetime est ISOString
-      if (!item.bookingLimitDatetime) return true
-      const bookingLimit = moment(item.bookingLimitDatetime)
-      return bookingLimit.isAfter(now)
-    })
-  return filtered
+  return stocks
+    .filter(stockItem => stockItem !== null)
+    .filter(checkIfStockBookingLimitDatetimeIsAfter(now))
 }
 
 export default filterAvailableStocks

--- a/src/helpers/filterAvailableStocks.js
+++ b/src/helpers/filterAvailableStocks.js
@@ -11,7 +11,7 @@ const filterAvailableStocks = stocks => {
       // item.bookingLimitDatetime est ISOString
       if (!item.bookingLimitDatetime) return true
       const bookingLimit = moment(item.bookingLimitDatetime)
-      return bookingLimit.isAfter(now, 'day')
+      return bookingLimit.isAfter(now)
     })
   return filtered
 }

--- a/src/helpers/tests/filterAvailableStocks.spec.js
+++ b/src/helpers/tests/filterAvailableStocks.spec.js
@@ -1,65 +1,42 @@
-// jest --env=jsdom ./src/helpers/tests/filterAvailableStocks --watch
 import moment from 'moment'
 import filterAvailableStocks from '../filterAvailableStocks'
 
 describe('src | helpers | filterAvailableStocks', () => {
-  it('returns an empty array', () => {
-    const expected = []
-    let stocks = null
-    let result = filterAvailableStocks(stocks)
-    expect(result).toStrictEqual(expected)
-    stocks = false
-    result = filterAvailableStocks(stocks)
-    expect(result).toStrictEqual(expected)
-    stocks = {}
-    result = filterAvailableStocks(stocks)
-    expect(result).toStrictEqual(expected)
-    stocks = 1234
-    result = filterAvailableStocks(stocks)
-    expect(result).toStrictEqual(expected)
-    stocks = undefined
-    result = filterAvailableStocks(stocks)
-    expect(result).toStrictEqual(expected)
-    stocks = 'a string'
-    result = filterAvailableStocks(stocks)
-    expect(result).toStrictEqual(expected)
-    stocks = []
-    result = filterAvailableStocks(stocks)
-    expect(result).toStrictEqual(expected)
-    stocks = [null, null]
-    result = filterAvailableStocks(stocks)
-    expect(result).toStrictEqual(expected)
+  it('should return an empty array when stocks is not an array', () => {
+    // when
+    const result = filterAvailableStocks({})
+
+    // then
+    expect(result).toEqual([])
   })
-  it('returns an array of objects without bookingLimitDatetime', () => {
-    const stocks = [
-      { notBookingLimitDatetime: true },
-      { bookingLimitDatetime: null },
-    ]
-    const expected = [
-      { notBookingLimitDatetime: true },
-      { bookingLimitDatetime: null },
-    ]
+
+  it('should return an array without null items', () => {
+    // given
+    const stocks = [{}, null, {}]
+
+    // when
     const result = filterAvailableStocks(stocks)
-    expect(result).toStrictEqual(expected)
+
+    // then
+    expect(result).toEqual([{}, {}])
   })
-  it('returns an array of objects with bookingLimitDatetime', () => {
-    const unvaliddatea = moment()
-    const unvaliddateb = moment().subtract(1, 'day')
-    const validdatea = moment().add(2, 'day')
-    const validdateb = moment().add(1, 'day')
+
+  it('should return an array containing stocks with booking limit datetime after now only', () => {
+    // given
+    const bookingLimitDatetimeOneDayAfterNow = moment().add(2, 'days')
+    const bookingLimitDatetimeOneDayBeforeNow = moment().subtract(2, 'days')
     const stocks = [
-      { bookingLimitDatetime: unvaliddatea },
-      { bookingLimitDatetime: unvaliddateb },
-      { bookingLimitDatetime: validdatea },
-      { bookingLimitDatetime: validdateb },
-      { bookingLimitDatetime: null },
+      { bookingLimitDatetime: bookingLimitDatetimeOneDayAfterNow },
+      { bookingLimitDatetime: bookingLimitDatetimeOneDayBeforeNow },
     ]
-    const expected = [
-      { bookingLimitDatetime: validdatea },
-      { bookingLimitDatetime: validdateb },
-      { bookingLimitDatetime: null },
-    ]
+
+    // when
     const result = filterAvailableStocks(stocks)
-    expect(result).toStrictEqual(expected)
+
+    // then
+    expect(result).toHaveLength(1)
+    expect(result).toEqual([
+      { bookingLimitDatetime: bookingLimitDatetimeOneDayAfterNow },
+    ])
   })
 })


### PR DESCRIPTION
Problème résolu : quand on mettait une date de réservation côté pro à l'heure d'aujourd'hui, on ne le voyait pas côté webapp.