### PR TITLE
(pC-1953) fix scroll removing is-relative

### DIFF
--- a/src/components/pages/search/Search.js
+++ b/src/components/pages/search/Search.js
@@ -262,7 +262,7 @@ class Search extends PureComponent {
             path="/recherche/(resultats)?/:option?/:subOption(menu)?"
             render={() => (
               <Fragment>
-                <div className="page-content is-relative">
+                <div className="page-content">
                   <form onSubmit={this.onSubmit}>
                     <div className="flex-columns items-start">
                       <div


### PR DESCRIPTION
Voir les derniers commentaires de Nicolas sur
https://passculture.atlassian.net/browse/PC-1953


Et du coup ca fixe aussi le 
'''
Impossible de décocher un filtre, si je séléctionne une distance, que je filtre puis que j’ouvre à nouveau les filtres, impossibles de décoché le filtre choisi, il se re-coche immédiatement
'''
(car le probleme c'est que le scroll cassé, ca triggerait la demande de la page n+1 toutes les 2s et donc demandait à l'history de repusher un url de page avec les parametres précédents)
