### PR TITLE
guard on recommendation in getCurrentRecommendationOfferName

### DIFF
--- a/src/selectors/currentRecommendation/getCurrentRecommendationOfferName.js
+++ b/src/selectors/currentRecommendation/getCurrentRecommendationOfferName.js
@@ -2,7 +2,7 @@ import { compose } from 'redux'
 import selectCurrentRecommendation from './currentRecommendation'
 
 const getRecommendationOfferName = recommendation => {
-  const { offer: { name = '' } = {} } = recommendation
+  const { offer: { name = '' } = {} } = recommendation || {}
   return name
 }
 

--- a/src/selectors/tests/getcurrentRecommendationOfferName.spec.js
+++ b/src/selectors/tests/getcurrentRecommendationOfferName.spec.js
@@ -1,9 +1,18 @@
-import { selectCurrentRecommendation } from '../currentRecommendation/currentRecommendation'
 import { getCurrentRecommendationOfferName } from '../currentRecommendation/getCurrentRecommendationOfferName'
+import { selectCurrentRecommendation } from '../currentRecommendation/currentRecommendation'
 
 jest.mock('../currentRecommendation/currentRecommendation')
 
 describe('getCurrentRecommendationOfferName', () => {
+  describe('when recommendation does not exist', () => {
+    it('should return empty string', () => {
+      // given
+      selectCurrentRecommendation.mockReturnValue(undefined)
+      // then
+      expect(getCurrentRecommendationOfferName({})).toBe('')
+    })
+  })
+
   describe('when current recommendation does exist', () => {
     describe('when offer not defined', () => {
       it('should return empty string', () => {


### PR DESCRIPTION
Permettant de refaire passer les tescafés, notamment pour les PRs 2049 et MOB