### PR TITLE
[QUICK WIN] Remove toBeDefined when its unnecessary within a test

### DIFF
--- a/src/components/booking/sub-items/tests/BookingCancel.spec.js
+++ b/src/components/booking/sub-items/tests/BookingCancel.spec.js
@@ -17,12 +17,11 @@ describe('src | components | booking | sub-items | BookingCancel', () => {
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<BookingCancel {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/booking/sub-items/tests/BookingError.spec.js
+++ b/src/components/booking/sub-items/tests/BookingError.spec.js
@@ -4,26 +4,30 @@ import { shallow } from 'enzyme'
 import BookingError from '../BookingError'
 
 describe('src | components | pages | search | BookingError', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const errors = {}
-      const wrapper = shallow(<BookingError errors={errors} />)
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+  it('should match the snapshot', () => {
+    // given
+    const errors = {}
+
+    // when
+    const wrapper = shallow(<BookingError errors={errors} />)
+
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
+
   describe('render', () => {
     it('when errors is an array, does not output any messages', () => {
       // given
       const props = { errors: ['do not output something'] }
+
       // when
       const wrapper = shallow(<BookingError {...props} />)
       const list = wrapper.find('#booking-error-reasons p')
+
       // then
       expect(list).toHaveLength(1)
     })
+
     it('when errors is an object, does output some messages', () => {
       // given
       const props = {
@@ -33,9 +37,11 @@ describe('src | components | pages | search | BookingError', () => {
           reason_34: ['Reason value 3', 'Reason value 4'],
         },
       }
+
       // when
       const wrapper = shallow(<BookingError {...props} />)
       const list = wrapper.find('#booking-error-reasons p')
+
       // then
       expect(list).toHaveLength(5)
       expect(list.at(1).text()).toStrictEqual('Reason value 1')

--- a/src/components/booking/sub-items/tests/BookingForm.spec.js
+++ b/src/components/booking/sub-items/tests/BookingForm.spec.js
@@ -5,18 +5,24 @@ import BookingForm from '../BookingForm'
 
 describe('src | components | pages | search | BookingForm', () => {
   describe('snapshot', () => {
-    it('should match snapshot', () => {
+    it('should match the snapshot', () => {
+      // given
       const props = {
         disabled: false,
         formId: 'super-form-id',
         onMutation: () => {},
         onSubmit: () => {},
       }
+
+      // when
       const wrapper = shallow(<BookingForm {...props} />)
-      expect(wrapper).toBeDefined()
+
+      // then
       expect(wrapper).toMatchSnapshot()
     })
-    it('should match snapshot when is read-only', () => {
+
+    it('should match the snapshot when is read-only', () => {
+      // given
       const props = {
         disabled: false,
         formId: 'super-form-id',
@@ -24,8 +30,11 @@ describe('src | components | pages | search | BookingForm', () => {
         onMutation: () => {},
         onSubmit: () => {},
       }
+
+      // when
       const wrapper = shallow(<BookingForm {...props} />)
-      expect(wrapper).toBeDefined()
+
+      // then
       expect(wrapper).toMatchSnapshot()
     })
   })

--- a/src/components/booking/sub-items/tests/BookingHeader.spec.js
+++ b/src/components/booking/sub-items/tests/BookingHeader.spec.js
@@ -4,20 +4,22 @@ import { shallow } from 'enzyme'
 import BookingHeader from '../BookingHeader'
 
 describe('src | components | booking | BookingHeader', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      const props = {
-        recommendation: {
-          offer: {
-            name: 'Titre de la recommendation',
-            product: { name: 'Titre de la recommendation' },
-            venue: { name: 'Titre de la venue ' },
-          },
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      recommendation: {
+        offer: {
+          name: 'Titre de la recommendation',
+          product: { name: 'Titre de la recommendation' },
+          venue: { name: 'Titre de la venue ' },
         },
-      }
-      const wrapper = shallow(<BookingHeader {...props} />)
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+      },
+    }
+
+    // when
+    const wrapper = shallow(<BookingHeader {...props} />)
+
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/booking/sub-items/tests/BookingLoader.spec.js
+++ b/src/components/booking/sub-items/tests/BookingLoader.spec.js
@@ -4,19 +4,16 @@ import { shallow } from 'enzyme'
 import BookingLoader from '../BookingLoader'
 
 describe('src | components | pages | search | BookingLoader', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        errors: {},
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      errors: {},
+    }
 
-      // when
-      const wrapper = shallow(<BookingLoader {...props} />)
+    // when
+    const wrapper = shallow(<BookingLoader {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/booking/sub-items/tests/BookingSuccess.spec.js
+++ b/src/components/booking/sub-items/tests/BookingSuccess.spec.js
@@ -4,22 +4,19 @@ import { shallow } from 'enzyme'
 import BookingSuccess from '../BookingSuccess'
 
 describe('src | components | pages | search | BookingSuccess', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        data: {
-          token: 'G8G8G8',
-        },
-        isEvent: true,
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      data: {
+        token: 'G8G8G8',
+      },
+      isEvent: true,
+    }
 
-      // when
-      const wrapper = shallow(<BookingSuccess {...props} />)
+    // when
+    const wrapper = shallow(<BookingSuccess {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/booking/sub-items/tests/__snapshots__/BookingCancel.spec.js.snap
+++ b/src/components/booking/sub-items/tests/__snapshots__/BookingCancel.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | booking | sub-items | BookingCancel should match snapshot 1`] = `
+exports[`src | components | booking | sub-items | BookingCancel should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingCancel

--- a/src/components/booking/sub-items/tests/__snapshots__/BookingError.spec.js.snap
+++ b/src/components/booking/sub-items/tests/__snapshots__/BookingError.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | search | BookingError snapshot should match snapshot 1`] = `
+exports[`src | components | pages | search | BookingError should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingError

--- a/src/components/booking/sub-items/tests/__snapshots__/BookingForm.spec.js.snap
+++ b/src/components/booking/sub-items/tests/__snapshots__/BookingForm.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | search | BookingForm snapshot should match snapshot 1`] = `
+exports[`src | components | pages | search | BookingForm snapshot should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingForm
@@ -88,7 +88,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | search | BookingForm snapshot should match snapshot when is read-only 1`] = `
+exports[`src | components | pages | search | BookingForm snapshot should match the snapshot when is read-only 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingForm

--- a/src/components/booking/sub-items/tests/__snapshots__/BookingHeader.spec.js.snap
+++ b/src/components/booking/sub-items/tests/__snapshots__/BookingHeader.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | booking | BookingHeader snapshot should match snapshot 1`] = `
+exports[`src | components | booking | BookingHeader should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingHeader

--- a/src/components/booking/sub-items/tests/__snapshots__/BookingLoader.spec.js.snap
+++ b/src/components/booking/sub-items/tests/__snapshots__/BookingLoader.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | search | BookingLoader snapshot should match snapshot 1`] = `
+exports[`src | components | pages | search | BookingLoader should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingLoader

--- a/src/components/booking/sub-items/tests/__snapshots__/BookingSuccess.spec.js.snap
+++ b/src/components/booking/sub-items/tests/__snapshots__/BookingSuccess.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | search | BookingSuccess snapshot should match snapshot 1`] = `
+exports[`src | components | pages | search | BookingSuccess should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingSuccess

--- a/src/components/booking/tests/Booking.spec.js
+++ b/src/components/booking/tests/Booking.spec.js
@@ -41,12 +41,11 @@ describe('src | components | booking', () => {
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<Booking {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/booking/tests/__snapshots__/Booking.spec.js.snap
+++ b/src/components/booking/tests/__snapshots__/Booking.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | booking should match snapshot 1`] = `
+exports[`src | components | booking should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Booking

--- a/src/components/forms/inputs/tests/CheckBoxField.spec.js
+++ b/src/components/forms/inputs/tests/CheckBoxField.spec.js
@@ -15,7 +15,6 @@ describe('src | components | forms | inputs | CheckBoxField', () => {
     const wrapper = shallow(<CheckBoxField {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/forms/inputs/tests/HiddenField.spec.js
+++ b/src/components/forms/inputs/tests/HiddenField.spec.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme'
 import HiddenField from '../HiddenField'
 
 describe('src | components | forms | inputs | HiddenField', () => {
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // given
     const props = {
       name: 'the-input-name',
@@ -14,7 +14,6 @@ describe('src | components | forms | inputs | HiddenField', () => {
     const wrapper = shallow(<HiddenField {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/forms/inputs/tests/__snapshots__/HiddenField.spec.js.snap
+++ b/src/components/forms/inputs/tests/__snapshots__/HiddenField.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | forms | inputs | HiddenField should match snapshot 1`] = `
+exports[`src | components | forms | inputs | HiddenField should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <HiddenField

--- a/src/components/forms/tests/FormFooter.spec.js
+++ b/src/components/forms/tests/FormFooter.spec.js
@@ -169,7 +169,6 @@ describe('src | components | forms | FormFooter', () => {
       const wrapper = shallow(<FormFooter {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
 
@@ -196,7 +195,6 @@ describe('src | components | forms | FormFooter', () => {
       const wrapper = shallow(<FormFooter {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
 
@@ -224,7 +222,6 @@ describe('src | components | forms | FormFooter', () => {
       const wrapper = shallow(<FormFooter {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
 
@@ -246,7 +243,6 @@ describe('src | components | forms | FormFooter', () => {
       const wrapper = shallow(<FormFooter {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
   })

--- a/src/components/hocs/with-login/__specs__/__snapshots__/withRequiredLogin.spec.js.snap
+++ b/src/components/hocs/with-login/__specs__/__snapshots__/withRequiredLogin.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | hocs | with-login | withRequiredLogin - unit tests snapshot should match snapshot 1`] = `
+exports[`src | components | pages | hocs | with-login | withRequiredLogin - unit tests should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <withRouter(_withQueryRouter) />,

--- a/src/components/hocs/with-login/__specs__/withNotRequiredLogin.spec.js
+++ b/src/components/hocs/with-login/__specs__/withNotRequiredLogin.spec.js
@@ -1,5 +1,4 @@
 import { shallow } from 'enzyme'
-import { createBrowserHistory } from 'history'
 import React from 'react'
 
 import withNotRequiredLogin, { handleSuccess } from '../withNotRequiredLogin'
@@ -16,7 +15,6 @@ describe('src | components | pages | hocs | with-login | withNotRequiredLogin', 
     const wrapper = shallow(<NotRequiredLoginTest />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/hocs/with-login/__specs__/withRequiredLogin.spec.js
+++ b/src/components/hocs/with-login/__specs__/withRequiredLogin.spec.js
@@ -1,11 +1,6 @@
-import { mount, shallow } from 'enzyme'
-import { createBrowserHistory } from 'history'
+import { shallow } from 'enzyme'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { Route, Router, Switch } from 'react-router-dom'
 
-import { configureTestStore } from './configure'
-import { OnMountCaller } from './OnMountCaller'
 import withRequiredLogin, {
   handleFail,
   handleSuccess,
@@ -25,15 +20,12 @@ describe('src | components | pages | hocs | with-login | withRequiredLogin - uni
     fetch.resetMocks()
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<RequiredLoginTest />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<RequiredLoginTest />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('handleFail()', () => {

--- a/src/components/layout/ErrorCatcher/tests/ErrorCatcher.spec.js
+++ b/src/components/layout/ErrorCatcher/tests/ErrorCatcher.spec.js
@@ -8,7 +8,7 @@ const routerProps = {
 }
 
 describe('src | components | layout | ErrorCatcher', () => {
-  it('match snapshot and render the children as is', () => {
+  it('should match the snapshot and render the children as is', () => {
     // given
     const props = { ...routerProps }
     const Children = () => <span>{'any child component'}</span>
@@ -21,10 +21,10 @@ describe('src | components | layout | ErrorCatcher', () => {
     ).dive()
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
-  it('match snapshot with error', () => {
+
+  it('should match the snapshot with error', () => {
     // given
     const Children = () => null
     const props = { ...routerProps }
@@ -39,9 +39,9 @@ describe('src | components | layout | ErrorCatcher', () => {
     wrapper.find(Children).simulateError(error)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
+
   it('do not render childrend if an error is throwned', () => {
     // given
     const Children = () => null
@@ -59,6 +59,7 @@ describe('src | components | layout | ErrorCatcher', () => {
     // then
     expect(Children).toHaveLength(0)
   })
+
   it('render catcher view if an error is throwned', () => {
     // given
     const Children = () => null
@@ -74,7 +75,6 @@ describe('src | components | layout | ErrorCatcher', () => {
     wrapper.find(Children).simulateError(error)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/layout/ErrorCatcher/tests/__snapshots__/ErrorCatcher.spec.js.snap
+++ b/src/components/layout/ErrorCatcher/tests/__snapshots__/ErrorCatcher.spec.js.snap
@@ -1,73 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | layout | ErrorCatcher match snapshot and render the children as is 1`] = `
-ShallowWrapper {
-  Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <Children />,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "checkPropTypes": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateError": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): Object {
-    "instance": null,
-    "key": undefined,
-    "nodeType": "host",
-    "props": Object {
-      "children": "any child component",
-    },
-    "ref": null,
-    "rendered": "any child component",
-    "type": "span",
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "host",
-      "props": Object {
-        "children": "any child component",
-      },
-      "ref": null,
-      "rendered": "any child component",
-      "type": "span",
-    },
-  ],
-  Symbol(enzyme.__options__): Object {
-    "adapter": ReactSixteenAdapter {
-      "options": Object {
-        "enableComponentDidUpdateOnSetState": true,
-        "legacyContextMode": "parent",
-        "lifecycles": Object {
-          "componentDidUpdate": Object {
-            "onSetState": true,
-          },
-          "getChildContext": Object {
-            "calledByRenderer": false,
-          },
-          "getDerivedStateFromError": true,
-          "getDerivedStateFromProps": Object {
-            "hasShouldComponentUpdateBug": false,
-          },
-          "getSnapshotBeforeUpdate": true,
-          "setState": Object {
-            "skipsComponentDidUpdateOnNullish": true,
-          },
-        },
-      },
-    },
-    "context": Object {},
-    Symbol(enzyme.__providerValues__): Map {},
-  },
-  Symbol(enzyme.__providerValues__): Map {},
-}
-`;
-
-exports[`src | components | layout | ErrorCatcher match snapshot with error 1`] = `
+exports[`src | components | layout | ErrorCatcher render catcher view if an error is throwned 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ErrorCatcher
@@ -362,7 +295,74 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | layout | ErrorCatcher render catcher view if an error is throwned 1`] = `
+exports[`src | components | layout | ErrorCatcher should match the snapshot and render the children as is 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Children />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": "any child component",
+    },
+    "ref": null,
+    "rendered": "any child component",
+    "type": "span",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": "any child component",
+      },
+      "ref": null,
+      "rendered": "any child component",
+      "type": "span",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromError": true,
+          "getDerivedStateFromProps": Object {
+            "hasShouldComponentUpdateBug": false,
+          },
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+    "context": Object {},
+    Symbol(enzyme.__providerValues__): Map {},
+  },
+  Symbol(enzyme.__providerValues__): Map {},
+}
+`;
+
+exports[`src | components | layout | ErrorCatcher should match the snapshot with error 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ErrorCatcher

--- a/src/components/layout/tests/Finishable.spec.js
+++ b/src/components/layout/tests/Finishable.spec.js
@@ -20,7 +20,6 @@ describe('src | components | layout | Finishable', () => {
     const wrapper = shallow(<Finishable {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/tests/MailToLink.spec.js
+++ b/src/components/layout/tests/MailToLink.spec.js
@@ -10,28 +10,25 @@ const children = (
 )
 
 describe('src | components | share | MailToLink', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        children,
-        email: 'email@fake.com',
-        header: {},
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      children,
+      email: 'email@fake.com',
+      header: {},
+    }
 
-      // when
-      const wrapper = shallow(<MailToLink {...props} />)
+    // when
+    const wrapper = shallow(<MailToLink {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
+
   describe('functions', () => {
     describe('onClickShare', () => {
       describe('when obfuscate is false', () => {
         it('should render Link', () => {
-          // given
           // given
           const props = {
             children,
@@ -42,10 +39,11 @@ describe('src | components | share | MailToLink', () => {
           // when
           const wrapper = shallow(<MailToLink {...props} />)
 
-          // // then
+          // then
           expect(wrapper.find('a').props().href).toStrictEqual('mailto:email@fake.com?')
         })
       })
+
       describe('when obfuscate is true', () => {
         // given
         const props = {
@@ -57,13 +55,15 @@ describe('src | components | share | MailToLink', () => {
           },
           obfuscate: true,
         }
-        it('should render Obfuscated Link ', () => {
+
+        it('should render Obfuscated Link', () => {
           // when
           const wrapper = shallow(<MailToLink {...props} />)
 
           // then
           expect(wrapper.find('a').props().href).toStrictEqual('mailto:obfuscated')
         })
+
         it.skip('should change window location on click', () => {
           // FIXME
           // Need to mock window.location.href

--- a/src/components/layout/tests/NavigationFooter.spec.js
+++ b/src/components/layout/tests/NavigationFooter.spec.js
@@ -9,26 +9,23 @@ const middlewares = []
 const mockStore = configureStore(middlewares)
 
 describe('src | components | pages | NavigationFooter', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const initialState = {}
-      const store = mockStore(initialState)
-      const props = {
-        dispatch: jest.fn(),
-        theme: 'fakeTheme',
-      }
+  it('should match the snapshot', () => {
+    // given
+    const initialState = {}
+    const store = mockStore(initialState)
+    const props = {
+      dispatch: jest.fn(),
+      theme: 'fakeTheme',
+    }
 
-      // when
-      const wrapper = shallow(
-        <Provider store={store}>
-          <NavigationFooter {...props} />
-        </Provider>
-      )
+    // when
+    const wrapper = shallow(
+      <Provider store={store}>
+        <NavigationFooter {...props} />
+      </Provider>
+    )
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/layout/tests/Price.spec.js
+++ b/src/components/layout/tests/Price.spec.js
@@ -5,52 +5,60 @@ import Price from '../Price'
 
 describe('src | components | pages | Price', () => {
   describe('snapshots', () => {
-    it('should match snapshot without props', () => {
+    it('should match the snapshot without props', () => {
       // given
       const props = {}
-      // when
-      const wrapper = shallow(<Price {...props} />)
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
-    it('should match snapshot with a price number', () => {
-      // given
-      const props = { value: 5 }
-      // when
-      const wrapper = shallow(<Price {...props} />)
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
-    it('should match snapshot with an array of prices number', () => {
-      // given
-      const props = { value: [5, 10] }
-      // when
-      const wrapper = shallow(<Price {...props} />)
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
-    it('should match snapshot with decimal prices', () => {
-      // given
-      const props = { value: [5.99, 10] }
-      // when
-      const wrapper = shallow(<Price {...props} />)
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
-    it('should match snapshot free prop defined and a zero price', () => {
-      // given
-      const props = { value: 0 }
 
       // when
       const wrapper = shallow(<Price {...props} />)
+
       // then
-      expect(wrapper).toBeDefined()
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it('should match the snapshot with a price number', () => {
+      // given
+      const props = { value: 5 }
+
+      // when
+      const wrapper = shallow(<Price {...props} />)
+
+      // then
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it('should match the snapshot with an array of prices number', () => {
+      // given
+      const props = { value: [5, 10] }
+
+      // when
+      const wrapper = shallow(<Price {...props} />)
+
+      // then
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it('should match the snapshot with decimal prices', () => {
+      // given
+      const props = { value: [5.99, 10] }
+
+      // when
+      const wrapper = shallow(<Price {...props} />)
+
+      // then
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it('should match the snapshot free prop defined and a zero price', () => {
+      // given
+      const props = { value: 0 }
+
+
+      // when
+      const wrapper = shallow(<Price {...props} />)
+
+      // then
       expect(wrapper).toMatchSnapshot()
     })
   })
-  describe('render', () => {})
 })

--- a/src/components/layout/tests/ProfilePicture.spec.js
+++ b/src/components/layout/tests/ProfilePicture.spec.js
@@ -6,18 +6,15 @@ import ProfilePicture from '../ProfilePicture'
 import { ROOT_PATH } from '../../../utils/config'
 
 describe('src | components | pages | ProfilePicture', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {}
+  it('should match the snapshot', () => {
+    // given
+    const props = {}
 
-      // when
-      const wrapper = shallow(<ProfilePicture {...props} />)
+    // when
+    const wrapper = shallow(<ProfilePicture {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/layout/tests/Splash.spec.js
+++ b/src/components/layout/tests/Splash.spec.js
@@ -9,30 +9,27 @@ const middlewares = []
 const mockStore = configureStore(middlewares)
 
 describe('src | components | layout | Splash', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const initialState = {}
-      const store = mockStore(initialState)
-      const props = {
-        closeTimeout: 1000,
-        dispatch: jest.fn(),
-        isBetaPage: true,
-      }
+  it('should match the snapshot', () => {
+    // given
+    const initialState = {}
+    const store = mockStore(initialState)
+    const props = {
+      closeTimeout: 1000,
+      dispatch: jest.fn(),
+      isBetaPage: true,
+    }
 
-      // when
-      const wrapper = shallow(
-        <Provider
-          store={store}
-          {...props}
-        >
-          <Splash />
-        </Provider>
-      )
+    // when
+    const wrapper = shallow(
+      <Provider
+        store={store}
+        {...props}
+      >
+        <Splash />
+      </Provider>
+    )
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/layout/tests/Thumb.spec.js
+++ b/src/components/layout/tests/Thumb.spec.js
@@ -4,20 +4,17 @@ import { shallow } from 'enzyme'
 import Thumb from '../Thumb'
 
 describe('src | components | pages | Thumb', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        title: 'fake title',
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      title: 'fake title',
+    }
 
-      // when
-      const wrapper = shallow(<Thumb {...props} />)
+    // when
+    const wrapper = shallow(<Thumb {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/layout/tests/__snapshots__/MailToLink.spec.js.snap
+++ b/src/components/layout/tests/__snapshots__/MailToLink.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | share | MailToLink snapshot should match snapshot 1`] = `
+exports[`src | components | share | MailToLink should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <MailToLink

--- a/src/components/layout/tests/__snapshots__/NavigationFooter.spec.js.snap
+++ b/src/components/layout/tests/__snapshots__/NavigationFooter.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | NavigationFooter snapshot should match snapshot 1`] = `
+exports[`src | components | pages | NavigationFooter should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Provider

--- a/src/components/layout/tests/__snapshots__/Price.spec.js.snap
+++ b/src/components/layout/tests/__snapshots__/Price.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Price snapshots should match snapshot free prop defined and a zero price 1`] = `
+exports[`src | components | pages | Price snapshots should match the snapshot free prop defined and a zero price 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Price
@@ -73,7 +73,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | Price snapshots should match snapshot with a price number 1`] = `
+exports[`src | components | pages | Price snapshots should match the snapshot with a price number 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Price
@@ -146,7 +146,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | Price snapshots should match snapshot with an array of prices number 1`] = `
+exports[`src | components | pages | Price snapshots should match the snapshot with an array of prices number 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Price
@@ -224,7 +224,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | Price snapshots should match snapshot with decimal prices 1`] = `
+exports[`src | components | pages | Price snapshots should match the snapshot with decimal prices 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Price
@@ -302,7 +302,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | Price snapshots should match snapshot without props 1`] = `
+exports[`src | components | pages | Price snapshots should match the snapshot without props 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Price

--- a/src/components/layout/tests/__snapshots__/ProfilePicture.spec.js.snap
+++ b/src/components/layout/tests/__snapshots__/ProfilePicture.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | ProfilePicture snapshot should match snapshot 1`] = `
+exports[`src | components | pages | ProfilePicture should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ProfilePicture

--- a/src/components/layout/tests/__snapshots__/Splash.spec.js.snap
+++ b/src/components/layout/tests/__snapshots__/Splash.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | layout | Splash snapshot should match snapshot 1`] = `
+exports[`src | components | layout | Splash should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Provider

--- a/src/components/layout/tests/__snapshots__/Thumb.spec.js.snap
+++ b/src/components/layout/tests/__snapshots__/Thumb.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Thumb snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Thumb should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Thumb

--- a/src/components/menu/__spec__/Header.spec.js
+++ b/src/components/menu/__spec__/Header.spec.js
@@ -20,7 +20,6 @@ describe('src | components | menu | Header', () => {
     const wrapper = shallow(<Header {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/menu/__spec__/Item.spec.js
+++ b/src/components/menu/__spec__/Item.spec.js
@@ -19,7 +19,6 @@ describe('src | components | menu | Item', () => {
     const wrapper = shallow(<Item {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/menu/__spec__/Menu.spec.jsx
+++ b/src/components/menu/__spec__/Menu.spec.jsx
@@ -38,7 +38,6 @@ describe('src | components | menu | Menu', () => {
     const wrapper = shallow(<Menu {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/menu/__spec__/MenuItem.spec.js
+++ b/src/components/menu/__spec__/MenuItem.spec.js
@@ -23,7 +23,6 @@ describe('src | components | menu | MenuItem', () => {
     const wrapper = shallow(<MenuItem {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/menu/__spec__/SignoutButton.spec.js
+++ b/src/components/menu/__spec__/SignoutButton.spec.js
@@ -18,7 +18,6 @@ describe('src | components | menu | SignoutButton', () => {
     const wrapper = shallow(<SignoutButton {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/activation/error/tests/ActivationError.spec.js
+++ b/src/components/pages/activation/error/tests/ActivationError.spec.js
@@ -6,12 +6,11 @@ import MailToLink from '../../../../layout/MailToLink'
 import { SUPPORT_EMAIL, SUPPORT_EMAIL_SUBJECT } from '../../../../../utils/config'
 
 describe('src | components | pages | activation | ActivationError', () => {
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<ActivationError />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/activation/error/tests/__snapshots__/ActivationError.spec.js.snap
+++ b/src/components/pages/activation/error/tests/__snapshots__/ActivationError.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | activation | ActivationError should match snapshot 1`] = `
+exports[`src | components | pages | activation | ActivationError should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ActivationError />,

--- a/src/components/pages/activation/password/tests/RawActivationPassword.spec.js
+++ b/src/components/pages/activation/password/tests/RawActivationPassword.spec.js
@@ -34,12 +34,11 @@ describe('src | components | pages | activation | password | RawActivationPasswo
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<RawActivationPassword {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/activation/password/tests/__snapshots__/RawActivationPassword.spec.js.snap
+++ b/src/components/pages/activation/password/tests/__snapshots__/RawActivationPassword.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | activation | password | RawActivationPassword should match snapshot 1`] = `
+exports[`src | components | pages | activation | password | RawActivationPassword should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <RawActivationPassword

--- a/src/components/pages/activation/tests/ActivationRoutes.spec.js
+++ b/src/components/pages/activation/tests/ActivationRoutes.spec.js
@@ -8,12 +8,11 @@ import InvalidLink from '../invalid-link/InvalidLink'
 import ActivationRoutes from '../ActivationRoutes'
 
 describe('src | components | pages | activation | ActivationRoutes', () => {
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<ActivationRoutes />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/activation/tests/__snapshots__/ActivationRoutes.spec.js.snap
+++ b/src/components/pages/activation/tests/__snapshots__/ActivationRoutes.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | activation | ActivationRoutes should match snapshot 1`] = `
+exports[`src | components | pages | activation | ActivationRoutes should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ActivationRoutes />,

--- a/src/components/pages/discovery/card/__specs__/__snapshots__/index.spec.js.snap
+++ b/src/components/pages/discovery/card/__specs__/__snapshots__/index.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | discovery | RawCard snapshot should match snapshot 1`] = `
+exports[`src | components | pages | discovery | RawCard should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <RawCard

--- a/src/components/pages/discovery/card/__specs__/index.spec.js
+++ b/src/components/pages/discovery/card/__specs__/index.spec.js
@@ -4,24 +4,21 @@ import { shallow } from 'enzyme'
 import { RawCard } from '../index'
 
 describe('src | components | pages | discovery | RawCard', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        handleClickRecommendation: jest.fn(),
-        handleReadRecommendation: jest.fn(),
-        loadRecommendation: jest.fn(),
-        position: 'position',
-        width: 500,
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      handleClickRecommendation: jest.fn(),
+      handleReadRecommendation: jest.fn(),
+      loadRecommendation: jest.fn(),
+      position: 'position',
+      width: 500,
+    }
 
-      // when
-      const wrapper = shallow(<RawCard {...props} />)
+    // when
+    const wrapper = shallow(<RawCard {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/pages/discovery/deck/tests/Deck.spec.js
+++ b/src/components/pages/discovery/deck/tests/Deck.spec.js
@@ -29,15 +29,12 @@ describe('src | components | pages | discovery | deck | Deck', () => {
     width: 500,
   }
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<Deck {...initialProps} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<Deck {...initialProps} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('react functions', () => {

--- a/src/components/pages/discovery/deck/tests/__snapshots__/Deck.spec.js.snap
+++ b/src/components/pages/discovery/deck/tests/__snapshots__/Deck.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | discovery | deck | Deck snapshot should match snapshot 1`] = `
+exports[`src | components | pages | discovery | deck | Deck should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Deck

--- a/src/components/pages/discovery/specs/DeckNavigation.spec.js
+++ b/src/components/pages/discovery/specs/DeckNavigation.spec.js
@@ -5,7 +5,7 @@ import { RawDeckNavigation } from '../DeckNavigation'
 
 describe('src | components | pages | discovery | RawDeckNavigation', () => {
   describe('snapshot', () => {
-    it('should match snapshot', () => {
+    it('should match the snapshot', () => {
       // given
       const props = {
         height: 500,
@@ -16,11 +16,10 @@ describe('src | components | pages | discovery | RawDeckNavigation', () => {
       const wrapper = shallow(<RawDeckNavigation {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
 
-    it('should match snapshot with flipHandler', () => {
+    it('should match the snapshot with flipHandler', () => {
       // given
       const props = {
         flipHandler: jest.fn(),
@@ -32,7 +31,6 @@ describe('src | components | pages | discovery | RawDeckNavigation', () => {
       const wrapper = shallow(<RawDeckNavigation {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
   })
@@ -51,13 +49,15 @@ describe('src | components | pages | discovery | RawDeckNavigation', () => {
             },
           },
         }
+
         // when
         const wrapper = mount(<RawDeckNavigation {...props} />)
         const element = wrapper.find('span#deck-navigation-offer-price')
+
         // then
-        expect(element).toBeDefined()
         expect(element.text()).toStrictEqual('Gratuit')
       })
+
       it(`should equal '0 -> 12 €' when offer price range is [0, 12]`, () => {
         // given
         const props = {
@@ -70,13 +70,15 @@ describe('src | components | pages | discovery | RawDeckNavigation', () => {
             },
           },
         }
+
         // when
         const wrapper = mount(<RawDeckNavigation {...props} />)
         const element = wrapper.find('span#deck-navigation-offer-price')
+
         // then
-        expect(element).toBeDefined()
         expect(element.text()).toStrictEqual('0 → 12 €')
       })
+
       it(`should equal '12 -> 56 €' when offer price range is [12, 56]`, () => {
         // given
         const props = {
@@ -93,11 +95,12 @@ describe('src | components | pages | discovery | RawDeckNavigation', () => {
             },
           },
         }
+
         // when
         const wrapper = mount(<RawDeckNavigation {...props} />)
         const element = wrapper.find('span#deck-navigation-offer-price')
+
         // then
-        expect(element).toBeDefined()
         expect(element.text()).toStrictEqual('12 → 56 €')
       })
     })

--- a/src/components/pages/discovery/specs/Discovery.spec.js
+++ b/src/components/pages/discovery/specs/Discovery.spec.js
@@ -37,7 +37,6 @@ describe('src | components | pages | discovery | Discovery', () => {
     const wrapper = shallow(<Discovery {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/discovery/specs/__snapshots__/DeckNavigation.spec.js.snap
+++ b/src/components/pages/discovery/specs/__snapshots__/DeckNavigation.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | discovery | RawDeckNavigation snapshot should match snapshot 1`] = `
+exports[`src | components | pages | discovery | RawDeckNavigation snapshot should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <RawDeckNavigation
@@ -198,7 +198,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | discovery | RawDeckNavigation snapshot should match snapshot with flipHandler 1`] = `
+exports[`src | components | pages | discovery | RawDeckNavigation snapshot should match the snapshot with flipHandler 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <RawDeckNavigation

--- a/src/components/pages/forgot-password/tests/RequestEmailForm.spec.js
+++ b/src/components/pages/forgot-password/tests/RequestEmailForm.spec.js
@@ -11,7 +11,6 @@ describe('src | components | pages | forgot-password | RawRequestEmailForm', () 
     const wrapper = shallow(<RawRequestEmailForm {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/forgot-password/tests/ResetThePasswordForm.spec.js
+++ b/src/components/pages/forgot-password/tests/ResetThePasswordForm.spec.js
@@ -11,7 +11,6 @@ describe('src |  components |  pages |  forgot-password |  ResetThePasswordForm'
     const wrapper = shallow(<RawResetThePasswordForm {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/forgot-password/tests/SuccessView.spec.js
+++ b/src/components/pages/forgot-password/tests/SuccessView.spec.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import SuccessView from '../SuccessView'
 
 describe('src | components | pages | forgot-password | SuccessView', () => {
-  it('should match snapshot without token', () => {
+  it('should match the snapshot without token', () => {
     // given
     const props = { token: null }
 
@@ -11,11 +11,10 @@ describe('src | components | pages | forgot-password | SuccessView', () => {
     const wrapper = shallow(<SuccessView {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 
-  it('should match snapshot with token', () => {
+  it('should match the snapshot with token', () => {
     // given
     const props = { token: '1234567890' }
 
@@ -23,7 +22,6 @@ describe('src | components | pages | forgot-password | SuccessView', () => {
     const wrapper = shallow(<SuccessView {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/forgot-password/tests/__snapshots__/SuccessView.spec.js.snap
+++ b/src/components/pages/forgot-password/tests/__snapshots__/SuccessView.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | forgot-password | SuccessView should match snapshot with token 1`] = `
+exports[`src | components | pages | forgot-password | SuccessView should match the snapshot with token 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <SuccessView
@@ -299,7 +299,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | forgot-password | SuccessView should match snapshot without token 1`] = `
+exports[`src | components | pages | forgot-password | SuccessView should match the snapshot without token 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <SuccessView

--- a/src/components/pages/profile/__specs__/MonPassCulture.spec.jsx
+++ b/src/components/pages/profile/__specs__/MonPassCulture.spec.jsx
@@ -8,7 +8,7 @@ const digitalId = '#profile-digital-wallet-value'
 const physicalId = '#profile-physical-wallet-value'
 
 describe('src | components | MonPassCulture', () => {
-  it('should match snapshot with required props', () => {
+  it('should match the snapshot with required props', () => {
     // given
     const props = {
       currentUser: {
@@ -24,7 +24,6 @@ describe('src | components | MonPassCulture', () => {
     const wrapper = shallow(<MonPassCulture {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/profile/__specs__/__snapshots__/MonPassCulture.spec.jsx.snap
+++ b/src/components/pages/profile/__specs__/__snapshots__/MonPassCulture.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | MonPassCulture should match snapshot with required props 1`] = `
+exports[`src | components | MonPassCulture should match the snapshot with required props 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <MonPassCulture

--- a/src/components/pages/profile/forms/__specs__/ProfileForm.spec.js
+++ b/src/components/pages/profile/forms/__specs__/ProfileForm.spec.js
@@ -38,7 +38,6 @@ describe('src | components | pages | profile | forms | ProfileForm', () => {
     const wrapper = shallow(<ProfileForm {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/profile/forms/fields/__specs__/UserIdentifierField.spec.js
+++ b/src/components/pages/profile/forms/fields/__specs__/UserIdentifierField.spec.js
@@ -12,12 +12,11 @@ describe('src | components | pages | profile | forms | fields | UserIdentifierFi
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<UserIdentifierField {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/profile/forms/fields/__specs__/UserPasswordField.spec.js
+++ b/src/components/pages/profile/forms/fields/__specs__/UserPasswordField.spec.js
@@ -17,12 +17,11 @@ describe('src | components | pages | profile | forms | fields | UserPasswordFiel
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<UserPasswordField {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/profile/forms/fields/__specs__/__snapshots__/UserIdentifierField.spec.js.snap
+++ b/src/components/pages/profile/forms/fields/__specs__/__snapshots__/UserIdentifierField.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | profile | forms | fields | UserIdentifierField should match snapshot 1`] = `
+exports[`src | components | pages | profile | forms | fields | UserIdentifierField should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Unknown

--- a/src/components/pages/profile/forms/fields/__specs__/__snapshots__/UserPasswordField.spec.js.snap
+++ b/src/components/pages/profile/forms/fields/__specs__/__snapshots__/UserPasswordField.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | profile | forms | fields | UserPasswordField should match snapshot 1`] = `
+exports[`src | components | pages | profile | forms | fields | UserPasswordField should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <UserPasswordField

--- a/src/components/pages/search/searchByType/tests/NavByOfferType.spec.js
+++ b/src/components/pages/search/searchByType/tests/NavByOfferType.spec.js
@@ -22,7 +22,6 @@ describe('src | components | search | searchByType | NavByOfferType', () => {
     const wrapper = shallow(<NavByOfferType {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/searchFilters/tests/SearchFilter.spec.js
+++ b/src/components/pages/search/searchFilters/tests/SearchFilter.spec.js
@@ -35,7 +35,6 @@ describe('src | components | pages | search | searchFilters | SearchFilter', () 
     const wrapper = shallow(<SearchFilter {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/tests/FilterByDates.spec.js
+++ b/src/components/pages/search/tests/FilterByDates.spec.js
@@ -41,7 +41,6 @@ describe('src | components | pages | search | FilterByDates', () => {
     const wrapper = shallow(<FilterByDates {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/tests/FilterByDistance.spec.js
+++ b/src/components/pages/search/tests/FilterByDistance.spec.js
@@ -40,7 +40,6 @@ describe('src | components | pages | search | FilterByDistance', () => {
     const wrapper = shallow(<FilterByDistance {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/tests/FilterByOfferTypes.spec.js
+++ b/src/components/pages/search/tests/FilterByOfferTypes.spec.js
@@ -43,7 +43,6 @@ describe('src | components | pages | search | FilterByOfferTypes', () => {
     const wrapper = shallow(<FilterByOfferTypes {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/tests/Footer.spec.js
+++ b/src/components/pages/search/tests/Footer.spec.js
@@ -9,7 +9,6 @@ describe('src | components | pages | search | Footer', () => {
     const wrapper = shallow(<Footer />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/search/tests/NavResultsHeader.spec.js
+++ b/src/components/pages/search/tests/NavResultsHeader.spec.js
@@ -20,7 +20,6 @@ describe('src | components | pages | search | NavResultsHeader', () => {
     const wrapper = shallow(<NavResultsHeader {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/tests/Search.spec.js
+++ b/src/components/pages/search/tests/Search.spec.js
@@ -91,15 +91,12 @@ describe('src | components | pages | Search', () => {
     typeSublabelsAndDescription: [],
   }
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<Search {...baseInitialProps} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<Search {...baseInitialProps} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('switch Route', () => {

--- a/src/components/pages/search/tests/SearchDetails.spec.js
+++ b/src/components/pages/search/tests/SearchDetails.spec.js
@@ -32,7 +32,6 @@ describe('src | components | pages | search | SearchDetails', () => {
     const wrapper = shallow(<SearchDetails {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/tests/SearchPicture.spec.js
+++ b/src/components/pages/search/tests/SearchPicture.spec.js
@@ -17,7 +17,6 @@ describe('src | components | pages | search | SearchPicture', () => {
     const wrapper = shallow(<SearchPicture {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/tests/SearchResultItem.spec.js
+++ b/src/components/pages/search/tests/SearchResultItem.spec.js
@@ -39,7 +39,6 @@ describe('src | components | pages | search | SearchResultItem', () => {
     const wrapper = shallow(<SearchResultItem {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/tests/SearchResults.spec.js
+++ b/src/components/pages/search/tests/SearchResults.spec.js
@@ -31,7 +31,6 @@ describe('src | components | pages | search | SearchResults', () => {
     const wrapper = shallow(<SearchResults {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/tests/__snapshots__/Search.spec.js.snap
+++ b/src/components/pages/search/tests/__snapshots__/Search.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Search snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Search should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Search

--- a/src/components/pages/signin/tests/FormHeader.spec.js
+++ b/src/components/pages/signin/tests/FormHeader.spec.js
@@ -4,17 +4,14 @@ import { shallow } from 'enzyme'
 import FormHeader from '../FormHeader'
 
 describe('src | components | pages | signin | FormHeader', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {}
+  it('should match the snapshot', () => {
+    // given
+    const props = {}
 
-      // when
-      const wrapper = shallow(<FormHeader {...props} />)
+    // when
+    const wrapper = shallow(<FormHeader {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/signin/tests/FormInputs.spec.js
+++ b/src/components/pages/signin/tests/FormInputs.spec.js
@@ -4,17 +4,14 @@ import { shallow } from 'enzyme'
 import FormInputs from '../FormInputs'
 
 describe('src | components | pages | signin | FormInputs', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {}
+  it('should match the snapshot', () => {
+    // given
+    const props = {}
 
-      // when
-      const wrapper = shallow(<FormInputs {...props} />)
+    // when
+    const wrapper = shallow(<FormInputs {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/signin/tests/Signin.spec.js
+++ b/src/components/pages/signin/tests/Signin.spec.js
@@ -19,7 +19,6 @@ describe('src | components | pages | signin | Signin', () => {
     const wrapper = shallow(<Signin {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/signin/tests/SigninContainer.spec.js
+++ b/src/components/pages/signin/tests/SigninContainer.spec.js
@@ -4,17 +4,14 @@ import React from 'react'
 import SigninContainer from '../SigninContainer'
 
 describe('src | components | pages | signin | Index', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {}
+  it('should match the snapshot', () => {
+    // given
+    const props = {}
 
-      // when
-      const wrapper = shallow(<SigninContainer {...props} />)
+    // when
+    const wrapper = shallow(<SigninContainer {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/signin/tests/__snapshots__/FormHeader.spec.js.snap
+++ b/src/components/pages/signin/tests/__snapshots__/FormHeader.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | signin | FormHeader snapshot should match snapshot 1`] = `
+exports[`src | components | pages | signin | FormHeader should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <FormHeader />,

--- a/src/components/pages/signin/tests/__snapshots__/FormInputs.spec.js.snap
+++ b/src/components/pages/signin/tests/__snapshots__/FormInputs.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | signin | FormInputs snapshot should match snapshot 1`] = `
+exports[`src | components | pages | signin | FormInputs should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <FormInputs />,

--- a/src/components/pages/signin/tests/__snapshots__/SigninContainer.spec.js.snap
+++ b/src/components/pages/signin/tests/__snapshots__/SigninContainer.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | signin | Index snapshot should match snapshot 1`] = `
+exports[`src | components | pages | signin | Index should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <withRouter(_withQueryRouter) />,

--- a/src/components/pages/tests/BetaPage.spec.js
+++ b/src/components/pages/tests/BetaPage.spec.js
@@ -5,17 +5,18 @@ import { MemoryRouter } from 'react-router-dom'
 import { RawBetaPage } from '../BetaPage'
 
 describe('src | components | pages | RawBetaPage', () => {
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = render(
       <MemoryRouter initialEntries={['/beta']}>
         <RawBetaPage />
       </MemoryRouter>
     )
+
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
+
   it('should contains a link to connexion page', () => {
     // when
     const wrapper = render(
@@ -23,8 +24,9 @@ describe('src | components | pages | RawBetaPage', () => {
         <RawBetaPage />
       </MemoryRouter>
     )
-    const element = wrapper.find('#beta-connexion-link')
+
     // then
+    const element = wrapper.find('#beta-connexion-link')
     expect(element).toHaveLength(1)
     expect(element.prop('href')).toStrictEqual('/connexion')
   })

--- a/src/components/pages/tests/__snapshots__/BetaPage.spec.js.snap
+++ b/src/components/pages/tests/__snapshots__/BetaPage.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | RawBetaPage should match snapshot 1`] = `
+exports[`src | components | pages | RawBetaPage should match the snapshot 1`] = `
 initialize {
   "0": Object {
     "attribs": Object {

--- a/src/components/pages/typeform/tests/TypeForm.spec.js
+++ b/src/components/pages/typeform/tests/TypeForm.spec.js
@@ -9,7 +9,7 @@ const history = createBrowserHistory()
 history.push('/typeform')
 
 describe('src | components | pages | typeform | TypeForm', () => {
-  it('should match snapshots with required props', () => {
+  it('should match the snapshots with required props', () => {
     // given
     const props = {
       flagUserHasFilledTypeform: jest.fn(),
@@ -27,7 +27,6 @@ describe('src | components | pages | typeform | TypeForm', () => {
     )
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/typeform/tests/__snapshots__/TypeForm.spec.js.snap
+++ b/src/components/pages/typeform/tests/__snapshots__/TypeForm.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | typeform | TypeForm should match snapshots with required props 1`] = `
+exports[`src | components | pages | typeform | TypeForm should match the snapshots with required props 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <MemoryRouter

--- a/src/components/recto/tests/Recto.spec.js
+++ b/src/components/recto/tests/Recto.spec.js
@@ -4,19 +4,16 @@ import { shallow } from 'enzyme'
 import Recto from '../Recto'
 
 describe('src | components | recto | Recto', () => {
-  describe('snapshot', () => {
-    it('should match snapshot with required props only', () => {
-      // given
-      const props = {
-        areDetailsVisible: true,
-      }
+  it('should match the snapshot with required props only', () => {
+    // given
+    const props = {
+      areDetailsVisible: true,
+    }
 
-      // when
-      const wrapper = shallow(<Recto {...props} />)
+    // when
+    const wrapper = shallow(<Recto {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/recto/tests/__snapshots__/Recto.spec.js.snap
+++ b/src/components/recto/tests/__snapshots__/Recto.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | recto | Recto snapshot should match snapshot with required props only 1`] = `
+exports[`src | components | recto | Recto should match the snapshot with required props only 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Recto

--- a/src/components/router/__specs__/FeaturedRoute.spec.jsx
+++ b/src/components/router/__specs__/FeaturedRoute.spec.jsx
@@ -21,7 +21,6 @@ describe('src | components | router | FeaturedRoute', () => {
     const wrapper = shallow(<FeaturedRoute {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/share/tests/CopyToClipboardButton.spec.js
+++ b/src/components/share/tests/CopyToClipboardButton.spec.js
@@ -6,19 +6,17 @@ import CopyToClipboardButton from '../CopyToClipboardButton'
 const onClickMock = jest.fn()
 
 describe('src | components | share | CopyToClipboardButton', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        onClick: onClickMock,
-        value: 'Fake Value',
-      }
-      // when
-      const wrapper = shallow(<CopyToClipboardButton {...props} />)
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      onClick: onClickMock,
+      value: 'Fake Value',
+    }
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // when
+    const wrapper = shallow(<CopyToClipboardButton {...props} />)
+
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/share/tests/SharePopin.spec.js
+++ b/src/components/share/tests/SharePopin.spec.js
@@ -11,26 +11,24 @@ const mockStore = configureStore(middlewares)
 const dispatchMock = jest.fn()
 
 describe('src | components | share | SharePopin', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const initialState = {}
-      const store = mockStore(initialState)
-      const props = {
-        dispatch: dispatchMock,
-        options: true,
-        visible: true,
-      }
-      // when
-      const wrapper = shallow(
-        <Provider store={store}>
-          <SharePopin {...props} />
-        </Provider>
-      )
+  it('should match the snapshot', () => {
+    // given
+    const initialState = {}
+    const store = mockStore(initialState)
+    const props = {
+      dispatch: dispatchMock,
+      options: true,
+      visible: true,
+    }
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // when
+    const wrapper = shallow(
+      <Provider store={store}>
+        <SharePopin {...props} />
+      </Provider>
+    )
+
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/share/tests/SharePopinContent.spec.js
+++ b/src/components/share/tests/SharePopinContent.spec.js
@@ -7,26 +7,23 @@ import CopyToClipboardButton from '../CopyToClipboardButton'
 const dispatchMock = jest.fn()
 
 describe('src | components | share | SharePopinContent', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        dispatch: dispatchMock,
-        options: {
-          text: 'Fake Test',
-          title: 'Fake Title',
-          url: 'fake@url.com',
-        },
-        visible: true,
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      dispatch: dispatchMock,
+      options: {
+        text: 'Fake Test',
+        title: 'Fake Title',
+        url: 'fake@url.com',
+      },
+      visible: true,
+    }
 
-      // when
-      const wrapper = shallow(<SharePopinContent {...props} />)
+    // when
+    const wrapper = shallow(<SharePopinContent {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('functions', () => {

--- a/src/components/share/tests/__snapshots__/CopyToClipboardButton.spec.js.snap
+++ b/src/components/share/tests/__snapshots__/CopyToClipboardButton.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | share | CopyToClipboardButton snapshot should match snapshot 1`] = `
+exports[`src | components | share | CopyToClipboardButton should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <CopyToClipboardButton

--- a/src/components/share/tests/__snapshots__/SharePopin.spec.js.snap
+++ b/src/components/share/tests/__snapshots__/SharePopin.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | share | SharePopin snapshot should match snapshot 1`] = `
+exports[`src | components | share | SharePopin should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Provider

--- a/src/components/share/tests/__snapshots__/SharePopinContent.spec.js.snap
+++ b/src/components/share/tests/__snapshots__/SharePopinContent.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | share | SharePopinContent snapshot should match snapshot 1`] = `
+exports[`src | components | share | SharePopinContent should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <SharePopinContent

--- a/src/components/verso/tests/Verso.spec.js
+++ b/src/components/verso/tests/Verso.spec.js
@@ -19,7 +19,7 @@ const props = {
 }
 
 describe('src | components | verso | Verso', () => {
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // given
     const cprops = { ...props, isTuto: false }
 
@@ -27,7 +27,6 @@ describe('src | components | verso | Verso', () => {
     const wrapper = shallow(<Verso {...cprops} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/verso/tests/__snapshots__/Verso.spec.js.snap
+++ b/src/components/verso/tests/__snapshots__/Verso.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | verso | Verso should match snapshot 1`] = `
+exports[`src | components | verso | Verso should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Verso

--- a/src/components/verso/verso-content/tests/VersoContentTuto.spec.js
+++ b/src/components/verso/verso-content/tests/VersoContentTuto.spec.js
@@ -12,7 +12,6 @@ describe('src | components | verso | verso-content | VersoContentTuto', () => {
     const wrapper = shallow(<VersoContentTuto {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/verso/verso-content/tests/VersoHeader.spec.js
+++ b/src/components/verso/verso-content/tests/VersoHeader.spec.js
@@ -11,12 +11,11 @@ const props = {
 }
 
 describe('src | components | verso | VersoHeader', () => {
-  it('should match snapshot with all props', () => {
+  it('should match the snapshot with all props', () => {
     // when
     const wrapper = shallow(<VersoHeader {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/verso/verso-content/tests/__snapshots__/VersoHeader.spec.js.snap
+++ b/src/components/verso/verso-content/tests/__snapshots__/VersoHeader.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | verso | VersoHeader should match snapshot with all props 1`] = `
+exports[`src | components | verso | VersoHeader should match the snapshot with all props 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <VersoHeader

--- a/src/components/verso/verso-content/verso-content-offer/tests/VersoContentOffer.spec.js
+++ b/src/components/verso/verso-content/verso-content-offer/tests/VersoContentOffer.spec.js
@@ -42,7 +42,7 @@ describe('src | components | verso | verso-content | verso-info-offer | VersoCon
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // given
     recommendation.offer.isThing = false
     recommendation.offer.isEvent = true
@@ -59,7 +59,6 @@ describe('src | components | verso | verso-content | verso-info-offer | VersoCon
     const wrapper = shallow(<VersoContentOffer {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 
@@ -220,7 +219,6 @@ describe('src | components | verso | verso-content | verso-info-offer | VersoCon
     const iconComponent = wrapper.find('.distance').find(Icon)
     expect(venueDistance.prop('href')).toBe('this is a fake url')
     expect(venueDistance.find('span').text()).toBe(`1${nbsp}`)
-    expect(iconComponent).toBeDefined()
     expect(iconComponent.prop('svg')).toBe('ico-geoloc-solid2')
     expect(iconComponent.prop('alt')).toBe('Géolocalisation dans Open Street Map')
   })

--- a/src/components/verso/verso-content/verso-content-offer/tests/__snapshots__/VersoContentOffer.spec.js.snap
+++ b/src/components/verso/verso-content/verso-content-offer/tests/__snapshots__/VersoContentOffer.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | verso | verso-content | verso-info-offer | VersoContentOffer should match snapshot 1`] = `
+exports[`src | components | verso | verso-content | verso-info-offer | VersoContentOffer should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <VersoContentOffer

--- a/src/components/verso/verso-controls/booking/book-this-link/tests/BookThisLink.spec.js
+++ b/src/components/verso/verso-controls/booking/book-this-link/tests/BookThisLink.spec.js
@@ -4,10 +4,9 @@ import { MemoryRouter } from 'react-router-dom'
 
 import Price from '../../../../../layout/Price'
 import BookThisLink from '../BookThisLink'
-import VersoPriceFormatter from '../../verso-price-formatter/VersoPriceFormatter'
 
 describe('src | components | verso | verso-controls | booking | BookThisLink', () => {
-  it('should match snapshot with required props', () => {
+  it('should match the snapshot with required props', () => {
     // given
     const props = {
       linkDestination: '/path/to/page/',
@@ -19,7 +18,6 @@ describe('src | components | verso | verso-controls | booking | BookThisLink', (
 
     // then
     const buttonLabel = wrapper.find('.pc-ticket-button-label')
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
     expect(buttonLabel).toHaveLength(1)
     expect(buttonLabel.text()).toBe('J’y vais !')

--- a/src/components/verso/verso-controls/booking/book-this-link/tests/__snapshots__/BookThisLink.spec.js.snap
+++ b/src/components/verso/verso-controls/booking/book-this-link/tests/__snapshots__/BookThisLink.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | verso | verso-controls | booking | BookThisLink should match snapshot with required props 1`] = `
+exports[`src | components | verso | verso-controls | booking | BookThisLink should match the snapshot with required props 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookThisLink

--- a/src/components/verso/verso-controls/booking/cancel-this-link/tests/CancelThisLink.spec.js
+++ b/src/components/verso/verso-controls/booking/cancel-this-link/tests/CancelThisLink.spec.js
@@ -30,15 +30,12 @@ describe('src | components | verso | verso-controls | booking | CancelThisLink',
     }
   })
 
-  describe('snapshot with required props', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<CancelThisLink {...props} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<CancelThisLink {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/verso/verso-controls/booking/cancel-this-link/tests/__snapshots__/CancelThisLink.spec.js.snap
+++ b/src/components/verso/verso-controls/booking/cancel-this-link/tests/__snapshots__/CancelThisLink.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | verso | verso-controls | booking | CancelThisLink snapshot with required props should match snapshot 1`] = `
+exports[`src | components | verso | verso-controls | booking | CancelThisLink should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <CancelThisLink

--- a/src/components/verso/verso-controls/booking/verso-price-formatter/tests/VersoPriceFormatter.spec.js
+++ b/src/components/verso/verso-controls/booking/verso-price-formatter/tests/VersoPriceFormatter.spec.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import VersoPriceFormatter from '../VersoPriceFormatter'
 
 describe('src | components | VersoPriceFormatter', () => {
-  it('should match snapshot with required price', () => {
+  it('should match the snapshot with required price', () => {
     // given
     const props = {
       devise: 'poires',
@@ -15,7 +15,6 @@ describe('src | components | VersoPriceFormatter', () => {
     const wrapper = shallow(<VersoPriceFormatter {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/verso/verso-controls/booking/verso-price-formatter/tests/__snapshots__/VersoPriceFormatter.spec.js.snap
+++ b/src/components/verso/verso-controls/booking/verso-price-formatter/tests/__snapshots__/VersoPriceFormatter.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | VersoPriceFormatter should match snapshot with required price 1`] = `
+exports[`src | components | VersoPriceFormatter should match the snapshot with required price 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <VersoPriceFormatter

--- a/src/components/verso/verso-controls/wallet/tests/VersoWallet.spec.js
+++ b/src/components/verso/verso-controls/wallet/tests/VersoWallet.spec.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import VersoWallet from '../VersoWallet'
 
 describe('src | components | verso | verso-controls | wallet | VersoWallet', () => {
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // given
     const props = { value: 10 }
 
@@ -11,7 +11,6 @@ describe('src | components | verso | verso-controls | wallet | VersoWallet', () 
     const wrapper = shallow(<VersoWallet {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/verso/verso-controls/wallet/tests/__snapshots__/VersoWallet.spec.js.snap
+++ b/src/components/verso/verso-controls/wallet/tests/__snapshots__/VersoWallet.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | verso | verso-controls | wallet | VersoWallet should match snapshot 1`] = `
+exports[`src | components | verso | verso-controls | wallet | VersoWallet should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <VersoWallet

--- a/src/selectors/tests/selectBookings.spec.js
+++ b/src/selectors/tests/selectBookings.spec.js
@@ -22,7 +22,6 @@ describe('src | selectors | selectBookings', () => {
       const result = selectBookingById(state, 'bar')
 
       // then
-      expect(result).toBeDefined()
       expect(result).toStrictEqual({ id: 'bar' })
       expect(result).toBe(state.data.bookings[1])
     })

--- a/src/tests/App.spec.js
+++ b/src/tests/App.spec.js
@@ -9,24 +9,22 @@ const middlewares = []
 const mockStore = configureStore(middlewares)
 
 describe('src | components | App', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const initialState = {}
-      const store = mockStore(initialState)
-      const props = {
-        location: {},
-      }
-      // when
-      const wrapper = shallow(
-        <Provider store={store}>
-          <App {...props} />
-        </Provider>
-      )
+  it('should match the snapshot', () => {
+    // given
+    const initialState = {}
+    const store = mockStore(initialState)
+    const props = {
+      location: {},
+    }
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // when
+    const wrapper = shallow(
+      <Provider store={store}>
+        <App {...props} />
+      </Provider>
+    )
+
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/tests/__snapshots__/App.spec.js.snap
+++ b/src/tests/__snapshots__/App.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | App snapshot should match snapshot 1`] = `
+exports[`src | components | App should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Provider


### PR DESCRIPTION
- Suppression de `toBeDefined` dans les tests quand ce n'est pas nécessaire (tel que décider en rétro tech) ;
- Renommage de `should match snapshot` en `should match the snapshot` (d'où le fait que les snapshots ont changés) ;
- Suppression de `describe('snapshot', () => {` quand inutile ;
- Suppression d'imports non utilisés
- En mode opportuniste, j'ai ajouté des `given/when/then` et des sauts de ligne quand ça manquait.