### PR TITLE
[QUICK WIN] Remove toBeDefined when its unnecessary within a test

### DIFF
--- a/src/__specs__/App.spec.js
+++ b/src/__specs__/App.spec.js
@@ -9,24 +9,22 @@ const middlewares = []
 const mockStore = configureStore(middlewares)
 
 describe('src | components | App', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const initialState = {}
-      const store = mockStore(initialState)
-      const props = {
-        location: {},
-      }
-      // when
-      const wrapper = shallow(
-        <Provider store={store}>
-          <App {...props} />
-        </Provider>
-      )
+  it('should match the snapshot', () => {
+    // given
+    const initialState = {}
+    const store = mockStore(initialState)
+    const props = {
+      location: {},
+    }
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // when
+    const wrapper = shallow(
+      <Provider store={store}>
+        <App {...props} />
+      </Provider>
+    )
+
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/__specs__/__snapshots__/App.spec.js.snap
+++ b/src/__specs__/__snapshots__/App.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | App snapshot should match snapshot 1`] = `
+exports[`src | components | App should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Provider

--- a/src/components/forms/__specs__/FormFooter.spec.js
+++ b/src/components/forms/__specs__/FormFooter.spec.js
@@ -6,6 +6,7 @@ import { FormFooter } from '../FormFooter'
 describe('src | components | forms | FormFooter', () => {
   describe('render', () => {
     const separatorSelector = 'hr.dotted-left-2x-white'
+
     it('hide separator when no submit and no cancel', () => {
       // given
       const props = {}
@@ -17,6 +18,7 @@ describe('src | components | forms | FormFooter', () => {
       // then
       expect(separator).toHaveLength(0)
     })
+
     it('hide separator when no cancel', () => {
       // given
       const props = {
@@ -34,6 +36,7 @@ describe('src | components | forms | FormFooter', () => {
       // then
       expect(separator).toHaveLength(0)
     })
+
     it('hide separator when no submit', () => {
       // given
       const props = {
@@ -52,6 +55,7 @@ describe('src | components | forms | FormFooter', () => {
       // then
       expect(separator).toHaveLength(0)
     })
+
     it('show separator when cancel and submit with no url', () => {
       // given
       const props = {
@@ -75,6 +79,7 @@ describe('src | components | forms | FormFooter', () => {
       // then
       expect(separator).toHaveLength(1)
     })
+
     it('show separator when cancel and submit with url', () => {
       // given
       const props = {
@@ -99,6 +104,7 @@ describe('src | components | forms | FormFooter', () => {
       // then
       expect(separator).toHaveLength(1)
     })
+
     it('render submit as submit button', () => {
       // given
       const props = {
@@ -156,7 +162,7 @@ describe('src | components | forms | FormFooter', () => {
     })
   })
 
-  describe('match snapshots', () => {
+  describe('match the snapshots', () => {
     it('hidden separator, cancel and submit buttons', () => {
       // given
       const props = {
@@ -169,7 +175,6 @@ describe('src | components | forms | FormFooter', () => {
       const wrapper = shallow(<FormFooter {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
 
@@ -196,7 +201,6 @@ describe('src | components | forms | FormFooter', () => {
       const wrapper = shallow(<FormFooter {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
 
@@ -224,7 +228,6 @@ describe('src | components | forms | FormFooter', () => {
       const wrapper = shallow(<FormFooter {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
 
@@ -246,7 +249,6 @@ describe('src | components | forms | FormFooter', () => {
       const wrapper = shallow(<FormFooter {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
   })

--- a/src/components/forms/__specs__/__snapshots__/FormFooter.spec.js.snap
+++ b/src/components/forms/__specs__/__snapshots__/FormFooter.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | forms | FormFooter match snapshots hidden separator, cancel and submit buttons 1`] = `
+exports[`src | components | forms | FormFooter match the snapshots hidden separator, cancel and submit buttons 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <FormFooter
@@ -93,7 +93,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | forms | FormFooter match snapshots hide cancel button 1`] = `
+exports[`src | components | forms | FormFooter match the snapshots hide cancel button 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <FormFooter
@@ -278,7 +278,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | forms | FormFooter match snapshots show submit as a text link 1`] = `
+exports[`src | components | forms | FormFooter match the snapshots show submit as a text link 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <FormFooter
@@ -579,7 +579,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | forms | FormFooter match snapshots show submit as submit button 1`] = `
+exports[`src | components | forms | FormFooter match the snapshots show submit as submit button 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <FormFooter

--- a/src/components/forms/inputs/__specs__/CheckBoxField.spec.js
+++ b/src/components/forms/inputs/__specs__/CheckBoxField.spec.js
@@ -15,7 +15,6 @@ describe('src | components | forms | inputs | CheckBoxField', () => {
     const wrapper = shallow(<CheckBoxField {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/forms/inputs/__specs__/HiddenField.spec.js
+++ b/src/components/forms/inputs/__specs__/HiddenField.spec.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme'
 import HiddenField from '../HiddenField'
 
 describe('src | components | forms | inputs | HiddenField', () => {
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // given
     const props = {
       name: 'the-input-name',
@@ -14,7 +14,6 @@ describe('src | components | forms | inputs | HiddenField', () => {
     const wrapper = shallow(<HiddenField {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/forms/inputs/__specs__/__snapshots__/HiddenField.spec.js.snap
+++ b/src/components/forms/inputs/__specs__/__snapshots__/HiddenField.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | forms | inputs | HiddenField should match snapshot 1`] = `
+exports[`src | components | forms | inputs | HiddenField should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <HiddenField

--- a/src/components/hocs/with-login/__specs__/__snapshots__/withRequiredLogin.spec.js.snap
+++ b/src/components/hocs/with-login/__specs__/__snapshots__/withRequiredLogin.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | hocs | with-login | withRequiredLogin - unit tests snapshot should match snapshot 1`] = `
+exports[`src | components | pages | hocs | with-login | withRequiredLogin - unit tests should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <withRouter(_withQueryRouter) />,

--- a/src/components/hocs/with-login/__specs__/withNotRequiredLogin.spec.js
+++ b/src/components/hocs/with-login/__specs__/withNotRequiredLogin.spec.js
@@ -1,5 +1,4 @@
 import { shallow } from 'enzyme'
-import { createBrowserHistory } from 'history'
 import React from 'react'
 
 import withNotRequiredLogin, { handleSuccess } from '../withNotRequiredLogin'
@@ -16,7 +15,6 @@ describe('src | components | pages | hocs | with-login | withNotRequiredLogin', 
     const wrapper = shallow(<NotRequiredLoginTest />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/hocs/with-login/__specs__/withRequiredLogin.spec.js
+++ b/src/components/hocs/with-login/__specs__/withRequiredLogin.spec.js
@@ -1,11 +1,6 @@
-import { mount, shallow } from 'enzyme'
-import { createBrowserHistory } from 'history'
+import { shallow } from 'enzyme'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { Route, Router, Switch } from 'react-router-dom'
 
-import { configureTestStore } from './configure'
-import { OnMountCaller } from './OnMountCaller'
 import withRequiredLogin, {
   handleFail,
   handleSuccess,
@@ -25,15 +20,12 @@ describe('src | components | pages | hocs | with-login | withRequiredLogin - uni
     fetch.resetMocks()
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<RequiredLoginTest />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<RequiredLoginTest />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('handleFail()', () => {

--- a/src/components/layout/Booking/__specs__/Booking.spec.js
+++ b/src/components/layout/Booking/__specs__/Booking.spec.js
@@ -49,12 +49,11 @@ describe('src | components | layout |Booking', () => {
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<Booking {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/Booking/__specs__/__snapshots__/Booking.spec.js.snap
+++ b/src/components/layout/Booking/__specs__/__snapshots__/Booking.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | layout |Booking should match snapshot 1`] = `
+exports[`src | components | layout |Booking should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Booking

--- a/src/components/layout/Booking/sub-items/__specs__/BookingCancel.spec.js
+++ b/src/components/layout/Booking/sub-items/__specs__/BookingCancel.spec.js
@@ -15,12 +15,11 @@ describe('src | components | booking | sub-items | BookingCancel', () => {
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<BookingCancel {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 
@@ -30,7 +29,6 @@ describe('src | components | booking | sub-items | BookingCancel', () => {
 
     // then
     const mainWrapper = wrapper.find('.text-center')
-    expect(mainWrapper).toBeDefined()
     const spans = mainWrapper.find('p span')
     expect(spans).toHaveLength(2)
     expect(spans.at(0).text()).toBe('12 € vont être recrédités sur votre pass.')

--- a/src/components/layout/Booking/sub-items/__specs__/BookingError.spec.js
+++ b/src/components/layout/Booking/sub-items/__specs__/BookingError.spec.js
@@ -4,26 +4,30 @@ import { shallow } from 'enzyme'
 import BookingError from '../BookingError'
 
 describe('src | components | pages | search | BookingError', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const errors = {}
-      const wrapper = shallow(<BookingError errors={errors} />)
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+  it('should match the snapshot', () => {
+    // given
+    const errors = {}
+
+    // when
+    const wrapper = shallow(<BookingError errors={errors} />)
+
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
+
   describe('render', () => {
     it('when errors is an array, does not output any messages', () => {
       // given
       const props = { errors: ['do not output something'] }
+
       // when
       const wrapper = shallow(<BookingError {...props} />)
       const list = wrapper.find('#booking-error-reasons p')
+
       // then
       expect(list).toHaveLength(1)
     })
+
     it('when errors is an object, does output some messages', () => {
       // given
       const props = {
@@ -33,9 +37,11 @@ describe('src | components | pages | search | BookingError', () => {
           reason_34: ['Reason value 3', 'Reason value 4'],
         },
       }
+
       // when
       const wrapper = shallow(<BookingError {...props} />)
       const list = wrapper.find('#booking-error-reasons p')
+
       // then
       expect(list).toHaveLength(5)
       expect(list.at(1).text()).toStrictEqual('Reason value 1')

--- a/src/components/layout/Booking/sub-items/__specs__/BookingForm.spec.js
+++ b/src/components/layout/Booking/sub-items/__specs__/BookingForm.spec.js
@@ -5,18 +5,24 @@ import BookingForm from '../BookingForm'
 
 describe('src | components | pages | search | BookingForm', () => {
   describe('snapshot', () => {
-    it('should match snapshot', () => {
+    it('should match the snapshot', () => {
+      // given
       const props = {
         disabled: false,
         formId: 'super-form-id',
         onMutation: () => {},
         onSubmit: () => {},
       }
+
+      // when
       const wrapper = shallow(<BookingForm {...props} />)
-      expect(wrapper).toBeDefined()
+
+      // then
       expect(wrapper).toMatchSnapshot()
     })
-    it('should match snapshot when is read-only', () => {
+
+    it('should match the snapshot when is read-only', () => {
+      // given
       const props = {
         disabled: false,
         formId: 'super-form-id',
@@ -24,8 +30,11 @@ describe('src | components | pages | search | BookingForm', () => {
         onMutation: () => {},
         onSubmit: () => {},
       }
+
+      // when
       const wrapper = shallow(<BookingForm {...props} />)
-      expect(wrapper).toBeDefined()
+
+      // then
       expect(wrapper).toMatchSnapshot()
     })
   })

--- a/src/components/layout/Booking/sub-items/__specs__/BookingHeader.spec.js
+++ b/src/components/layout/Booking/sub-items/__specs__/BookingHeader.spec.js
@@ -4,20 +4,22 @@ import { shallow } from 'enzyme'
 import BookingHeader from '../BookingHeader'
 
 describe('src | components | booking | BookingHeader', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      const props = {
-        recommendation: {
-          offer: {
-            name: 'Titre de la recommendation',
-            product: { name: 'Titre de la recommendation' },
-            venue: { name: 'Titre de la venue ' },
-          },
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      recommendation: {
+        offer: {
+          name: 'Titre de la recommendation',
+          product: { name: 'Titre de la recommendation' },
+          venue: { name: 'Titre de la venue ' },
         },
-      }
-      const wrapper = shallow(<BookingHeader {...props} />)
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+      },
+    }
+
+    // when
+    const wrapper = shallow(<BookingHeader {...props} />)
+
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/layout/Booking/sub-items/__specs__/BookingLoader.spec.js
+++ b/src/components/layout/Booking/sub-items/__specs__/BookingLoader.spec.js
@@ -4,19 +4,16 @@ import { shallow } from 'enzyme'
 import BookingLoader from '../BookingLoader'
 
 describe('src | components | pages | search | BookingLoader', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        errors: {},
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      errors: {},
+    }
 
-      // when
-      const wrapper = shallow(<BookingLoader {...props} />)
+    // when
+    const wrapper = shallow(<BookingLoader {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/layout/Booking/sub-items/__specs__/BookingSuccess.spec.js
+++ b/src/components/layout/Booking/sub-items/__specs__/BookingSuccess.spec.js
@@ -4,22 +4,19 @@ import { shallow } from 'enzyme'
 import BookingSuccess from '../BookingSuccess'
 
 describe('src | components | pages | search | BookingSuccess', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        data: {
-          token: 'G8G8G8',
-        },
-        isEvent: true,
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      data: {
+        token: 'G8G8G8',
+      },
+      isEvent: true,
+    }
 
-      // when
-      const wrapper = shallow(<BookingSuccess {...props} />)
+    // when
+    const wrapper = shallow(<BookingSuccess {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/layout/Booking/sub-items/__specs__/__snapshots__/BookingCancel.spec.js.snap
+++ b/src/components/layout/Booking/sub-items/__specs__/__snapshots__/BookingCancel.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | booking | sub-items | BookingCancel should match snapshot 1`] = `
+exports[`src | components | booking | sub-items | BookingCancel should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingCancel

--- a/src/components/layout/Booking/sub-items/__specs__/__snapshots__/BookingError.spec.js.snap
+++ b/src/components/layout/Booking/sub-items/__specs__/__snapshots__/BookingError.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | search | BookingError snapshot should match snapshot 1`] = `
+exports[`src | components | pages | search | BookingError should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingError

--- a/src/components/layout/Booking/sub-items/__specs__/__snapshots__/BookingForm.spec.js.snap
+++ b/src/components/layout/Booking/sub-items/__specs__/__snapshots__/BookingForm.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | search | BookingForm snapshot should match snapshot 1`] = `
+exports[`src | components | pages | search | BookingForm snapshot should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingForm
@@ -88,7 +88,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | search | BookingForm snapshot should match snapshot when is read-only 1`] = `
+exports[`src | components | pages | search | BookingForm snapshot should match the snapshot when is read-only 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingForm

--- a/src/components/layout/Booking/sub-items/__specs__/__snapshots__/BookingHeader.spec.js.snap
+++ b/src/components/layout/Booking/sub-items/__specs__/__snapshots__/BookingHeader.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | booking | BookingHeader snapshot should match snapshot 1`] = `
+exports[`src | components | booking | BookingHeader should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingHeader

--- a/src/components/layout/Booking/sub-items/__specs__/__snapshots__/BookingLoader.spec.js.snap
+++ b/src/components/layout/Booking/sub-items/__specs__/__snapshots__/BookingLoader.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | search | BookingLoader snapshot should match snapshot 1`] = `
+exports[`src | components | pages | search | BookingLoader should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingLoader

--- a/src/components/layout/Booking/sub-items/__specs__/__snapshots__/BookingSuccess.spec.js.snap
+++ b/src/components/layout/Booking/sub-items/__specs__/__snapshots__/BookingSuccess.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | search | BookingSuccess snapshot should match snapshot 1`] = `
+exports[`src | components | pages | search | BookingSuccess should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookingSuccess

--- a/src/components/layout/ErrorCatcher/__specs__/ErrorCatcher.spec.js
+++ b/src/components/layout/ErrorCatcher/__specs__/ErrorCatcher.spec.js
@@ -8,7 +8,7 @@ const routerProps = {
 }
 
 describe('src | components | layout | ErrorCatcher', () => {
-  it('match snapshot and render the children as is', () => {
+  it('should match the snapshot and render the children as is', () => {
     // given
     const props = { ...routerProps }
     const Children = () => <span>{'any child component'}</span>
@@ -21,10 +21,10 @@ describe('src | components | layout | ErrorCatcher', () => {
     ).dive()
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
-  it('match snapshot with error', () => {
+
+  it('should match the snapshot with error', () => {
     // given
     const Children = () => null
     const props = { ...routerProps }
@@ -39,9 +39,9 @@ describe('src | components | layout | ErrorCatcher', () => {
     wrapper.find(Children).simulateError(error)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
+
   it('do not render childrend if an error is throwned', () => {
     // given
     const Children = () => null
@@ -59,6 +59,7 @@ describe('src | components | layout | ErrorCatcher', () => {
     // then
     expect(Children).toHaveLength(0)
   })
+
   it('render catcher view if an error is throwned', () => {
     // given
     const Children = () => null
@@ -74,7 +75,6 @@ describe('src | components | layout | ErrorCatcher', () => {
     wrapper.find(Children).simulateError(error)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/layout/ErrorCatcher/__specs__/__snapshots__/ErrorCatcher.spec.js.snap
+++ b/src/components/layout/ErrorCatcher/__specs__/__snapshots__/ErrorCatcher.spec.js.snap
@@ -1,73 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | layout | ErrorCatcher match snapshot and render the children as is 1`] = `
-ShallowWrapper {
-  Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <Children />,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "checkPropTypes": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateError": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): Object {
-    "instance": null,
-    "key": undefined,
-    "nodeType": "host",
-    "props": Object {
-      "children": "any child component",
-    },
-    "ref": null,
-    "rendered": "any child component",
-    "type": "span",
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "host",
-      "props": Object {
-        "children": "any child component",
-      },
-      "ref": null,
-      "rendered": "any child component",
-      "type": "span",
-    },
-  ],
-  Symbol(enzyme.__options__): Object {
-    "adapter": ReactSixteenAdapter {
-      "options": Object {
-        "enableComponentDidUpdateOnSetState": true,
-        "legacyContextMode": "parent",
-        "lifecycles": Object {
-          "componentDidUpdate": Object {
-            "onSetState": true,
-          },
-          "getChildContext": Object {
-            "calledByRenderer": false,
-          },
-          "getDerivedStateFromError": true,
-          "getDerivedStateFromProps": Object {
-            "hasShouldComponentUpdateBug": false,
-          },
-          "getSnapshotBeforeUpdate": true,
-          "setState": Object {
-            "skipsComponentDidUpdateOnNullish": true,
-          },
-        },
-      },
-    },
-    "context": Object {},
-    Symbol(enzyme.__providerValues__): Map {},
-  },
-  Symbol(enzyme.__providerValues__): Map {},
-}
-`;
-
-exports[`src | components | layout | ErrorCatcher match snapshot with error 1`] = `
+exports[`src | components | layout | ErrorCatcher render catcher view if an error is throwned 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ErrorCatcher
@@ -362,7 +295,74 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | layout | ErrorCatcher render catcher view if an error is throwned 1`] = `
+exports[`src | components | layout | ErrorCatcher should match the snapshot and render the children as is 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Children />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": "any child component",
+    },
+    "ref": null,
+    "rendered": "any child component",
+    "type": "span",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": "any child component",
+      },
+      "ref": null,
+      "rendered": "any child component",
+      "type": "span",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromError": true,
+          "getDerivedStateFromProps": Object {
+            "hasShouldComponentUpdateBug": false,
+          },
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+    "context": Object {},
+    Symbol(enzyme.__providerValues__): Map {},
+  },
+  Symbol(enzyme.__providerValues__): Map {},
+}
+`;
+
+exports[`src | components | layout | ErrorCatcher should match the snapshot with error 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ErrorCatcher

--- a/src/components/layout/Finishable/__specs__/Finishable.spec.js
+++ b/src/components/layout/Finishable/__specs__/Finishable.spec.js
@@ -20,7 +20,6 @@ describe('src | components | layout | Finishable', () => {
     const wrapper = shallow(<Finishable {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/Menu/Header/__specs__/Header.spec.js
+++ b/src/components/layout/Menu/Header/__specs__/Header.spec.js
@@ -20,7 +20,6 @@ describe('src | components | menu | Header', () => {
     const wrapper = shallow(<Header {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/Menu/MenuItem/Item/__specs__/Item.spec.js
+++ b/src/components/layout/Menu/MenuItem/Item/__specs__/Item.spec.js
@@ -19,7 +19,6 @@ describe('src | components | menu | Item', () => {
     const wrapper = shallow(<Item {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/Menu/MenuItem/__specs__/MenuItem.spec.js
+++ b/src/components/layout/Menu/MenuItem/__specs__/MenuItem.spec.js
@@ -24,7 +24,6 @@ describe('src | components | menu | MenuItem', () => {
     const wrapper = shallow(<MenuItem {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/Menu/SignoutButton/__specs__/SignoutButton.spec.js
+++ b/src/components/layout/Menu/SignoutButton/__specs__/SignoutButton.spec.js
@@ -18,7 +18,6 @@ describe('src | components | menu | SignoutButton', () => {
     const wrapper = shallow(<SignoutButton {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/Menu/__specs__/Menu.spec.js
+++ b/src/components/layout/Menu/__specs__/Menu.spec.js
@@ -38,7 +38,6 @@ describe('src | components | menu | Menu', () => {
     const wrapper = shallow(<Menu {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/Recto/__specs__/Recto.spec.js
+++ b/src/components/layout/Recto/__specs__/Recto.spec.js
@@ -4,19 +4,16 @@ import { shallow } from 'enzyme'
 import Recto from '../Recto'
 
 describe('src | components | recto | Recto', () => {
-  describe('snapshot', () => {
-    it('should match snapshot with required props only', () => {
-      // given
-      const props = {
-        areDetailsVisible: true,
-      }
+  it('should match the snapshot with required props only', () => {
+    // given
+    const props = {
+      areDetailsVisible: true,
+    }
 
-      // when
-      const wrapper = shallow(<Recto {...props} />)
+    // when
+    const wrapper = shallow(<Recto {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/layout/Recto/__specs__/Thumb.spec.js
+++ b/src/components/layout/Recto/__specs__/Thumb.spec.js
@@ -4,20 +4,17 @@ import { shallow } from 'enzyme'
 import Thumb from '../Thumb'
 
 describe('src | components | pages | Thumb', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        title: 'fake title',
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      title: 'fake title',
+    }
 
-      // when
-      const wrapper = shallow(<Thumb {...props} />)
+    // when
+    const wrapper = shallow(<Thumb {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/layout/Recto/__specs__/__snapshots__/Recto.spec.js.snap
+++ b/src/components/layout/Recto/__specs__/__snapshots__/Recto.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | recto | Recto snapshot should match snapshot with required props only 1`] = `
+exports[`src | components | recto | Recto should match the snapshot with required props only 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Recto

--- a/src/components/layout/Recto/__specs__/__snapshots__/Thumb.spec.js.snap
+++ b/src/components/layout/Recto/__specs__/__snapshots__/Thumb.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Thumb snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Thumb should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Thumb

--- a/src/components/layout/RelativeFooter/__specs__/RelativeFooter.spec.js
+++ b/src/components/layout/RelativeFooter/__specs__/RelativeFooter.spec.js
@@ -4,19 +4,16 @@ import { shallow } from 'enzyme'
 import RelativeFooter from '../RelativeFooter'
 
 describe('src | components | pages | RelativeFooter', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        theme: 'fakeTheme',
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      theme: 'fakeTheme',
+    }
 
-      // when
-      const wrapper = shallow(<RelativeFooter {...props} />)
+    // when
+    const wrapper = shallow(<RelativeFooter {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/layout/RelativeFooter/__specs__/__snapshots__/RelativeFooter.spec.js.snap
+++ b/src/components/layout/RelativeFooter/__specs__/__snapshots__/RelativeFooter.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | RelativeFooter snapshot should match snapshot 1`] = `
+exports[`src | components | pages | RelativeFooter should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <withRouter(NavigationFooter)

--- a/src/components/layout/Share/ShareButton/__specs__/ShareButton.spec.js
+++ b/src/components/layout/Share/ShareButton/__specs__/ShareButton.spec.js
@@ -19,7 +19,6 @@ describe('src | components | share | ShareButton', () => {
     const wrapper = shallow(<ShareButton {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/Share/ShareButton/__specs__/ShareButtonContainer.spec.js
+++ b/src/components/layout/Share/ShareButton/__specs__/ShareButtonContainer.spec.js
@@ -17,7 +17,7 @@ const dispatchMock = jest.fn()
 
 describe('src | components | share | ShareButtonContainer', () => {
   describe('snapshot', () => {
-    it('should match snapshot', () => {
+    it('should match the snapshot', () => {
       // given
       const initialState = {
         options: {},

--- a/src/components/layout/Share/ShareButton/__specs__/__snapshots__/ShareButtonContainer.spec.js.snap
+++ b/src/components/layout/Share/ShareButton/__specs__/__snapshots__/ShareButtonContainer.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | share | ShareButtonContainer snapshot should match snapshot 1`] = `
+exports[`src | components | share | ShareButtonContainer snapshot should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Provider

--- a/src/components/layout/Share/__specs__/CopyToClipboardButton.spec.js
+++ b/src/components/layout/Share/__specs__/CopyToClipboardButton.spec.js
@@ -6,19 +6,16 @@ import CopyToClipboardButton from '../CopyToClipboardButton'
 const onClickMock = jest.fn()
 
 describe('src | components | share | CopyToClipboardButton', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        onClick: onClickMock,
-        value: 'Fake Value',
-      }
-      // when
-      const wrapper = shallow(<CopyToClipboardButton {...props} />)
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      onClick: onClickMock,
+      value: 'Fake Value',
+    }
+    // when
+    const wrapper = shallow(<CopyToClipboardButton {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/layout/Share/__specs__/SharePopin.spec.js
+++ b/src/components/layout/Share/__specs__/SharePopin.spec.js
@@ -6,26 +6,23 @@ import SharePopin from '../SharePopin'
 const dispatchMock = jest.fn()
 
 describe('src | components | share | SharePopin', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        dispatch: dispatchMock,
-        options: {
-          text: 'Fake Test',
-          title: 'Fake Title',
-          url: 'fake@url.com',
-        },
-        visible: true,
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      dispatch: dispatchMock,
+      options: {
+        text: 'Fake Test',
+        title: 'Fake Title',
+        url: 'fake@url.com',
+      },
+      visible: true,
+    }
 
-      // when
-      const wrapper = shallow(<SharePopin {...props} />)
+    // when
+    const wrapper = shallow(<SharePopin {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('functions', () => {

--- a/src/components/layout/Share/__specs__/SharePopinContainer.spec.js
+++ b/src/components/layout/Share/__specs__/SharePopinContainer.spec.js
@@ -11,26 +11,24 @@ const mockStore = configureStore(middlewares)
 const dispatchMock = jest.fn()
 
 describe('src | components | share | SharePopinContainer', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const initialState = {}
-      const store = mockStore(initialState)
-      const props = {
-        dispatch: dispatchMock,
-        options: true,
-        visible: true,
-      }
-      // when
-      const wrapper = shallow(
-        <Provider store={store}>
-          <SharePopinContainer {...props} />
-        </Provider>
-      )
+  it('should match the snapshot', () => {
+    // given
+    const initialState = {}
+    const store = mockStore(initialState)
+    const props = {
+      dispatch: dispatchMock,
+      options: true,
+      visible: true,
+    }
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // when
+    const wrapper = shallow(
+      <Provider store={store}>
+        <SharePopinContainer {...props} />
+      </Provider>
+    )
+
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/layout/Share/__specs__/__snapshots__/CopyToClipboardButton.spec.js.snap
+++ b/src/components/layout/Share/__specs__/__snapshots__/CopyToClipboardButton.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | share | CopyToClipboardButton snapshot should match snapshot 1`] = `
+exports[`src | components | share | CopyToClipboardButton should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <CopyToClipboardButton

--- a/src/components/layout/Share/__specs__/__snapshots__/SharePopin.spec.js.snap
+++ b/src/components/layout/Share/__specs__/__snapshots__/SharePopin.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | share | SharePopin snapshot should match snapshot 1`] = `
+exports[`src | components | share | SharePopin should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <SharePopin

--- a/src/components/layout/Share/__specs__/__snapshots__/SharePopinContainer.spec.js.snap
+++ b/src/components/layout/Share/__specs__/__snapshots__/SharePopinContainer.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | share | SharePopinContainer snapshot should match snapshot 1`] = `
+exports[`src | components | share | SharePopinContainer should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Provider

--- a/src/components/layout/Verso/VersoControls/Wallet/__specs__/Wallet.spec.js
+++ b/src/components/layout/Verso/VersoControls/Wallet/__specs__/Wallet.spec.js
@@ -4,7 +4,7 @@ import React from 'react'
 import Wallet from '../Wallet'
 
 describe('src | components | verso | verso-controls | wallet | Wallet', () => {
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // given
     const props = { value: 10 }
 
@@ -12,7 +12,6 @@ describe('src | components | verso | verso-controls | wallet | Wallet', () => {
     const wrapper = shallow(<Wallet {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/Verso/VersoControls/Wallet/__specs__/__snapshots__/Wallet.spec.js.snap
+++ b/src/components/layout/Verso/VersoControls/Wallet/__specs__/__snapshots__/Wallet.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | verso | verso-controls | wallet | Wallet should match snapshot 1`] = `
+exports[`src | components | verso | verso-controls | wallet | Wallet should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Wallet

--- a/src/components/layout/Verso/VersoControls/booking/BookThisLink/__specs__/BookThisLink.spec.js
+++ b/src/components/layout/Verso/VersoControls/booking/BookThisLink/__specs__/BookThisLink.spec.js
@@ -23,13 +23,12 @@ describe('src | components | verso | verso-controls | booking | BookThisLink', (
     }
   })
 
-  it('should match snapshot with required props', () => {
+  it('should match the snapshot with required props', () => {
     // when
     const wrapper = shallow(<BookThisLink {...props} />)
 
     // then
     const buttonLabel = wrapper.find('.pc-ticket-button-label')
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
     expect(buttonLabel).toHaveLength(1)
     expect(buttonLabel.text()).toBe('J’y vais !')

--- a/src/components/layout/Verso/VersoControls/booking/BookThisLink/__specs__/__snapshots__/BookThisLink.spec.js.snap
+++ b/src/components/layout/Verso/VersoControls/booking/BookThisLink/__specs__/__snapshots__/BookThisLink.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | verso | verso-controls | booking | BookThisLink should match snapshot with required props 1`] = `
+exports[`src | components | verso | verso-controls | booking | BookThisLink should match the snapshot with required props 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BookThisLink

--- a/src/components/layout/Verso/VersoControls/booking/VersoPriceFormatter/__specs__/VersoPriceFormatter.spec.jsx
+++ b/src/components/layout/Verso/VersoControls/booking/VersoPriceFormatter/__specs__/VersoPriceFormatter.spec.jsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import VersoPriceFormatter from '../VersoPriceFormatter'
 
 describe('src | components | VersoPriceFormatter', () => {
-  it('should match snapshot with required price', () => {
+  it('should match the snapshot with required price', () => {
     // given
     const props = {
       devise: 'poires',
@@ -15,7 +15,6 @@ describe('src | components | VersoPriceFormatter', () => {
     const wrapper = shallow(<VersoPriceFormatter {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/Verso/VersoControls/booking/VersoPriceFormatter/__specs__/__snapshots__/VersoPriceFormatter.spec.jsx.snap
+++ b/src/components/layout/Verso/VersoControls/booking/VersoPriceFormatter/__specs__/__snapshots__/VersoPriceFormatter.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | VersoPriceFormatter should match snapshot with required price 1`] = `
+exports[`src | components | VersoPriceFormatter should match the snapshot with required price 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <VersoPriceFormatter

--- a/src/components/layout/Verso/__specs__/Verso.spec.jsx
+++ b/src/components/layout/Verso/__specs__/Verso.spec.jsx
@@ -19,12 +19,11 @@ const props = {
 }
 
 describe('src | components | verso | Verso', () => {
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<Verso {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/Verso/__specs__/__snapshots__/Verso.spec.jsx.snap
+++ b/src/components/layout/Verso/__specs__/__snapshots__/Verso.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | verso | Verso should match snapshot 1`] = `
+exports[`src | components | verso | Verso should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Verso

--- a/src/components/layout/Verso/verso-content/VersoContentOffer/__specs__/VersoContentOffer.spec.js
+++ b/src/components/layout/Verso/verso-content/VersoContentOffer/__specs__/VersoContentOffer.spec.js
@@ -53,7 +53,7 @@ describe('src | components | layout | Verso | verso-content | VersoContentOffer 
     expect(distanceElement.props()).toHaveProperty('target', '_blank')
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // given
     offer.isThing = false
     offer.isEvent = true
@@ -239,7 +239,6 @@ describe('src | components | layout | Verso | verso-content | VersoContentOffer 
     const iconComponent = wrapper.find('.distance').find(Icon)
     expect(venueDistance.prop('href')).toBe('this is a fake url')
     expect(venueDistance.find('span').text()).toBe(`1${nbsp}`)
-    expect(iconComponent).toBeDefined()
     expect(iconComponent.prop('svg')).toBe('ico-geoloc-solid2')
     expect(iconComponent.prop('alt')).toBe('Géolocalisation dans Open Street Map')
   })

--- a/src/components/layout/Verso/verso-content/VersoContentOffer/__specs__/__snapshots__/VersoContentOffer.spec.js.snap
+++ b/src/components/layout/Verso/verso-content/VersoContentOffer/__specs__/__snapshots__/VersoContentOffer.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | layout | Verso | verso-content | VersoContentOffer | VersoContentOffer should match snapshot 1`] = `
+exports[`src | components | layout | Verso | verso-content | VersoContentOffer | VersoContentOffer should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <VersoContentOffer

--- a/src/components/layout/Verso/verso-content/VersoContentTuto/__specs__/VersoContentTuto.spec.js
+++ b/src/components/layout/Verso/verso-content/VersoContentTuto/__specs__/VersoContentTuto.spec.js
@@ -12,7 +12,6 @@ describe('src | components | verso | verso-content | VersoContentTuto', () => {
     const wrapper = shallow(<VersoContentTuto {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/Verso/verso-content/__specs__/VersoHeader.spec.js
+++ b/src/components/layout/Verso/verso-content/__specs__/VersoHeader.spec.js
@@ -17,12 +17,11 @@ const props = {
 }
 
 describe('src | components | verso | VersoHeader', () => {
-  it('should match snapshot with all props', () => {
+  it('should match the snapshot with all props', () => {
     // when
     const wrapper = shallow(<VersoHeader {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/Verso/verso-content/__specs__/__snapshots__/VersoHeader.spec.js.snap
+++ b/src/components/layout/Verso/verso-content/__specs__/__snapshots__/VersoHeader.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | verso | VersoHeader should match snapshot with all props 1`] = `
+exports[`src | components | verso | VersoHeader should match the snapshot with all props 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <VersoHeader

--- a/src/components/layout/__specs__/MailToLink.spec.js
+++ b/src/components/layout/__specs__/MailToLink.spec.js
@@ -10,73 +10,71 @@ const children = (
 )
 
 describe('src | components | share | MailToLink', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        children,
-        email: 'email@fake.com',
-        header: {},
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      children,
+      email: 'email@fake.com',
+      header: {},
+    }
 
-      // when
-      const wrapper = shallow(<MailToLink {...props} />)
+    // when
+    const wrapper = shallow(<MailToLink {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
-  describe('functions', () => {
-    describe('onClickShare', () => {
-      describe('when obfuscate is false', () => {
-        it('should render Link', () => {
-          // given
-          // given
-          const props = {
-            children,
-            email: 'email@fake.com',
-            header: {},
-          }
 
-          // when
-          const wrapper = shallow(<MailToLink {...props} />)
-
-          // // then
-          expect(wrapper.find('a').props().href).toStrictEqual('mailto:email@fake.com?')
-        })
-      })
-      describe('when obfuscate is true', () => {
+  describe('onClickShare', () => {
+    describe('when obfuscate is false', () => {
+      it('should render Link', () => {
         // given
         const props = {
           children,
           email: 'email@fake.com',
-          headers: {
-            body: 'http://localhost:3000/decouverte/AE/?shared_by=AE',
-            subject: 'Fake Title',
-          },
-          obfuscate: true,
+          header: {},
         }
-        it('should render Obfuscated Link ', () => {
-          // when
-          const wrapper = shallow(<MailToLink {...props} />)
 
-          // then
-          expect(wrapper.find('a').props().href).toStrictEqual('mailto:obfuscated')
-        })
-        it.skip('should change window location on click', () => {
-          // FIXME
-          // Need to mock window.location.href
-          // when
-          const wrapper = shallow(<MailToLink {...props} />)
-          const event = Object.assign(jest.fn(), { preventDefault: () => {} })
-          wrapper.find('a').simulate('click', event)
+        // when
+        const wrapper = shallow(<MailToLink {...props} />)
 
-          // then
-          expect(window.location.href).toStrictEqual(
-            'mailto:email@fake.com?body=http%3A%2F%2Flocalhost%3A3000%2Fdecouverte%2FAE%2F%3Fshared_by%3DAE&subject=Fake%20Title'
-          )
-        })
+        // // then
+        expect(wrapper.find('a').props().href).toStrictEqual('mailto:email@fake.com?')
+      })
+    })
+
+    describe('when obfuscate is true', () => {
+      // given
+      const props = {
+        children,
+        email: 'email@fake.com',
+        headers: {
+          body: 'http://localhost:3000/decouverte/AE/?shared_by=AE',
+          subject: 'Fake Title',
+        },
+        obfuscate: true,
+      }
+
+      it('should render Obfuscated Link ', () => {
+        // when
+        const wrapper = shallow(<MailToLink {...props} />)
+
+        // then
+        expect(wrapper.find('a').props().href).toStrictEqual('mailto:obfuscated')
+      })
+
+      it.skip('should change window location on click', () => {
+        // FIXME
+        // Need to mock window.location.href
+        // when
+        const wrapper = shallow(<MailToLink {...props} />)
+        const event = Object.assign(jest.fn(), { preventDefault: () => {} })
+        wrapper.find('a').simulate('click', event)
+
+        // then
+        expect(window.location.href).toStrictEqual(
+          'mailto:email@fake.com?body=http%3A%2F%2Flocalhost%3A3000%2Fdecouverte%2FAE%2F%3Fshared_by%3DAE&subject=Fake%20Title'
+        )
       })
     })
   })

--- a/src/components/layout/__specs__/Price.spec.js
+++ b/src/components/layout/__specs__/Price.spec.js
@@ -4,53 +4,58 @@ import { shallow } from 'enzyme'
 import Price from '../Price'
 
 describe('src | components | pages | Price', () => {
-  describe('snapshots', () => {
-    it('should match snapshot without props', () => {
-      // given
-      const props = {}
-      // when
-      const wrapper = shallow(<Price {...props} />)
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
-    it('should match snapshot with a price number', () => {
-      // given
-      const props = { value: 5 }
-      // when
-      const wrapper = shallow(<Price {...props} />)
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
-    it('should match snapshot with an array of prices number', () => {
-      // given
-      const props = { value: [5, 10] }
-      // when
-      const wrapper = shallow(<Price {...props} />)
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
-    it('should match snapshot with decimal prices', () => {
-      // given
-      const props = { value: [5.99, 10] }
-      // when
-      const wrapper = shallow(<Price {...props} />)
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
-    it('should match snapshot free prop defined and a zero price', () => {
-      // given
-      const props = { value: 0 }
+  it('should match the snapshot without props', () => {
+    // given
+    const props = {}
 
-      // when
-      const wrapper = shallow(<Price {...props} />)
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // when
+    const wrapper = shallow(<Price {...props} />)
+
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
-  describe('render', () => {})
+
+  it('should match the snapshot with a price number', () => {
+    // given
+    const props = { value: 5 }
+
+    // when
+    const wrapper = shallow(<Price {...props} />)
+
+    // then
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('should match the snapshot with an array of prices number', () => {
+    // given
+    const props = { value: [5, 10] }
+
+    // when
+    const wrapper = shallow(<Price {...props} />)
+
+    // then
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('should match the snapshot with decimal prices', () => {
+    // given
+    const props = { value: [5.99, 10] }
+
+    // when
+    const wrapper = shallow(<Price {...props} />)
+
+    // then
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('should match the snapshot free prop defined and a zero price', () => {
+    // given
+    const props = { value: 0 }
+
+    // when
+    const wrapper = shallow(<Price {...props} />)
+
+    // then
+    expect(wrapper).toMatchSnapshot()
+  })
 })

--- a/src/components/layout/__specs__/ProfilePicture.spec.js
+++ b/src/components/layout/__specs__/ProfilePicture.spec.js
@@ -6,18 +6,15 @@ import ProfilePicture from '../ProfilePicture'
 import { ROOT_PATH } from '../../../utils/config'
 
 describe('src | components | pages | ProfilePicture', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {}
+  it('should match the snapshot', () => {
+    // given
+    const props = {}
 
-      // when
-      const wrapper = shallow(<ProfilePicture {...props} />)
+    // when
+    const wrapper = shallow(<ProfilePicture {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {
@@ -32,8 +29,8 @@ describe('src | components | pages | ProfilePicture', () => {
       const img = wrapper.find('img').props()
 
       // then
-      expect(img.src).toStrictEqual(`${ROOT_PATH}/icons/ico-user-circled-w.svg`)
-      expect(img.alt).toStrictEqual('Avatar')
+      expect(img.src).toBe(`${ROOT_PATH}/icons/ico-user-circled-w.svg`)
+      expect(img.alt).toBe('Avatar')
     })
   })
 })

--- a/src/components/layout/__specs__/Splash.spec.js
+++ b/src/components/layout/__specs__/Splash.spec.js
@@ -9,30 +9,27 @@ const middlewares = []
 const mockStore = configureStore(middlewares)
 
 describe('src | components | layout | Splash', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const initialState = {}
-      const store = mockStore(initialState)
-      const props = {
-        closeTimeout: 1000,
-        dispatch: jest.fn(),
-        isBetaPage: true,
-      }
+  it('should match the snapshot', () => {
+    // given
+    const initialState = {}
+    const store = mockStore(initialState)
+    const props = {
+      closeTimeout: 1000,
+      dispatch: jest.fn(),
+      isBetaPage: true,
+    }
 
-      // when
-      const wrapper = shallow(
-        <Provider
-          store={store}
-          {...props}
-        >
-          <Splash />
-        </Provider>
-      )
+    // when
+    const wrapper = shallow(
+      <Provider
+        store={store}
+        {...props}
+      >
+        <Splash />
+      </Provider>
+    )
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/layout/__specs__/__snapshots__/MailToLink.spec.js.snap
+++ b/src/components/layout/__specs__/__snapshots__/MailToLink.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | share | MailToLink snapshot should match snapshot 1`] = `
+exports[`src | components | share | MailToLink should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <MailToLink

--- a/src/components/layout/__specs__/__snapshots__/Price.spec.js.snap
+++ b/src/components/layout/__specs__/__snapshots__/Price.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Price snapshots should match snapshot free prop defined and a zero price 1`] = `
+exports[`src | components | pages | Price should match the snapshot free prop defined and a zero price 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Price
@@ -73,7 +73,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | Price snapshots should match snapshot with a price number 1`] = `
+exports[`src | components | pages | Price should match the snapshot with a price number 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Price
@@ -146,7 +146,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | Price snapshots should match snapshot with an array of prices number 1`] = `
+exports[`src | components | pages | Price should match the snapshot with an array of prices number 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Price
@@ -224,7 +224,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | Price snapshots should match snapshot with decimal prices 1`] = `
+exports[`src | components | pages | Price should match the snapshot with decimal prices 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Price
@@ -302,7 +302,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | Price snapshots should match snapshot without props 1`] = `
+exports[`src | components | pages | Price should match the snapshot without props 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Price

--- a/src/components/layout/__specs__/__snapshots__/ProfilePicture.spec.js.snap
+++ b/src/components/layout/__specs__/__snapshots__/ProfilePicture.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | ProfilePicture snapshot should match snapshot 1`] = `
+exports[`src | components | pages | ProfilePicture should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ProfilePicture

--- a/src/components/layout/__specs__/__snapshots__/Splash.spec.js.snap
+++ b/src/components/layout/__specs__/__snapshots__/Splash.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | layout | Splash snapshot should match snapshot 1`] = `
+exports[`src | components | layout | Splash should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Provider

--- a/src/components/pages/__specs__/BetaPage.spec.js
+++ b/src/components/pages/__specs__/BetaPage.spec.js
@@ -5,17 +5,18 @@ import { MemoryRouter } from 'react-router-dom'
 import { RawBetaPage } from '../BetaPage'
 
 describe('src | components | pages | RawBetaPage', () => {
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = render(
       <MemoryRouter initialEntries={['/beta']}>
         <RawBetaPage />
       </MemoryRouter>
     )
+
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
+
   it('should contains a link to connexion page', () => {
     // when
     const wrapper = render(
@@ -24,6 +25,7 @@ describe('src | components | pages | RawBetaPage', () => {
       </MemoryRouter>
     )
     const element = wrapper.find('#beta-connexion-link')
+
     // then
     expect(element).toHaveLength(1)
     expect(element.prop('href')).toStrictEqual('/connexion')

--- a/src/components/pages/__specs__/__snapshots__/BetaPage.spec.js.snap
+++ b/src/components/pages/__specs__/__snapshots__/BetaPage.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | RawBetaPage should match snapshot 1`] = `
+exports[`src | components | pages | RawBetaPage should match the snapshot 1`] = `
 initialize {
   "0": Object {
     "attribs": Object {

--- a/src/components/pages/activation/PasswordForm/__specs__/PasswordForm.spec.js
+++ b/src/components/pages/activation/PasswordForm/__specs__/PasswordForm.spec.js
@@ -35,12 +35,11 @@ describe('src | components | pages | activation | password | Password', () => {
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<PasswordForm {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/activation/PasswordForm/__specs__/__snapshots__/PasswordForm.spec.js.snap
+++ b/src/components/pages/activation/PasswordForm/__specs__/__snapshots__/PasswordForm.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | activation | password | Password should match snapshot 1`] = `
+exports[`src | components | pages | activation | password | Password should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <PasswordForm

--- a/src/components/pages/activation/__specs__/Activation.spec.js
+++ b/src/components/pages/activation/__specs__/Activation.spec.js
@@ -9,12 +9,11 @@ import InvalidLink from '../InvalidLink'
 import Activation from '../Activation'
 
 describe('src | components | pages | activation | Activation', () => {
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<Activation />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/activation/__specs__/Error.spec.js
+++ b/src/components/pages/activation/__specs__/Error.spec.js
@@ -6,12 +6,11 @@ import MailToLink from '../../../layout/MailToLink'
 import { SUPPORT_EMAIL, SUPPORT_EMAIL_SUBJECT } from '../../../../utils/config'
 
 describe('src | components | pages | activation | Error', () => {
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<Error />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/activation/__specs__/__snapshots__/Activation.spec.js.snap
+++ b/src/components/pages/activation/__specs__/__snapshots__/Activation.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | activation | Activation should match snapshot 1`] = `
+exports[`src | components | pages | activation | Activation should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Activation />,

--- a/src/components/pages/activation/__specs__/__snapshots__/Error.spec.js.snap
+++ b/src/components/pages/activation/__specs__/__snapshots__/Error.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | activation | Error should match snapshot 1`] = `
+exports[`src | components | pages | activation | Error should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Error />,

--- a/src/components/pages/discovery/Deck/Card/__specs__/Card.spec.jsx
+++ b/src/components/pages/discovery/Deck/Card/__specs__/Card.spec.jsx
@@ -4,25 +4,23 @@ import { shallow } from 'enzyme'
 import Card from '../Card'
 
 describe('src | components | pages | discovery | Deck | Card', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        handleClickRecommendation: jest.fn(),
-        handleReadRecommendation: jest.fn(),
-        match: { params: {} },
-        position: 'position',
-        width: 500,
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      handleClickRecommendation: jest.fn(),
+      handleReadRecommendation: jest.fn(),
+      match: { params: {} },
+      position: 'position',
+      width: 500,
+    }
 
-      // when
-      const wrapper = shallow(<Card {...props} />)
+    // when
+    const wrapper = shallow(<Card {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
+
   describe('render', () => {
     describe('background Color', () => {
       describe('when no color given in recommendation', () => {

--- a/src/components/pages/discovery/Deck/Card/__specs__/__snapshots__/Card.spec.jsx.snap
+++ b/src/components/pages/discovery/Deck/Card/__specs__/__snapshots__/Card.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | discovery | Deck | Card snapshot should match snapshot 1`] = `
+exports[`src | components | pages | discovery | Deck | Card should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Card

--- a/src/components/pages/discovery/Deck/Navigation/__specs__/Navigation.spec.jsx
+++ b/src/components/pages/discovery/Deck/Navigation/__specs__/Navigation.spec.jsx
@@ -5,7 +5,7 @@ import Navigation from '../Navigation'
 
 describe('src | components | pages | discovery | Deck | Navigation', () => {
   describe('snapshot', () => {
-    it('should match snapshot', () => {
+    it('should match the snapshot', () => {
       // given
       const props = {
         backgroundGradient: 'black',
@@ -20,11 +20,10 @@ describe('src | components | pages | discovery | Deck | Navigation', () => {
       const wrapper = shallow(<Navigation {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
 
-    it('should match snapshot with flipHandler', () => {
+    it('should match the snapshot with flipHandler', () => {
       // given
       const props = {
         backgroundGradient: 'black',
@@ -39,7 +38,6 @@ describe('src | components | pages | discovery | Deck | Navigation', () => {
       const wrapper = shallow(<Navigation {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
   })

--- a/src/components/pages/discovery/Deck/Navigation/__specs__/__snapshots__/Navigation.spec.jsx.snap
+++ b/src/components/pages/discovery/Deck/Navigation/__specs__/__snapshots__/Navigation.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | discovery | Deck | Navigation snapshot should match snapshot 1`] = `
+exports[`src | components | pages | discovery | Deck | Navigation snapshot should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Navigation
@@ -1254,7 +1254,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | discovery | Deck | Navigation snapshot should match snapshot with flipHandler 1`] = `
+exports[`src | components | pages | discovery | Deck | Navigation snapshot should match the snapshot with flipHandler 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Navigation

--- a/src/components/pages/discovery/Deck/__specs__/Deck.spec.jsx
+++ b/src/components/pages/discovery/Deck/__specs__/Deck.spec.jsx
@@ -31,15 +31,12 @@ describe('src | components | pages | discovery | Deck | Deck', () => {
     width: 500,
   }
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<Deck {...initialProps} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<Deck {...initialProps} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('react functions', () => {

--- a/src/components/pages/discovery/Deck/__specs__/__snapshots__/Deck.spec.jsx.snap
+++ b/src/components/pages/discovery/Deck/__specs__/__snapshots__/Deck.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | discovery | Deck | Deck snapshot should match snapshot 1`] = `
+exports[`src | components | pages | discovery | Deck | Deck should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Deck

--- a/src/components/pages/discovery/__specs__/Discovery.spec.js
+++ b/src/components/pages/discovery/__specs__/Discovery.spec.js
@@ -39,7 +39,6 @@ describe('src | components | pages | discovery | Discovery', () => {
     const wrapper = shallow(<Discovery {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/forgot-password/__specs__/RequestEmailForm.spec.js
+++ b/src/components/pages/forgot-password/__specs__/RequestEmailForm.spec.js
@@ -11,7 +11,6 @@ describe('src | components | pages | forgot-password | RawRequestEmailForm', () 
     const wrapper = shallow(<RawRequestEmailForm {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/forgot-password/__specs__/ResetThePasswordForm.spec.js
+++ b/src/components/pages/forgot-password/__specs__/ResetThePasswordForm.spec.js
@@ -11,7 +11,6 @@ describe('src |  components |  pages |  forgot-password |  ResetThePasswordForm'
     const wrapper = shallow(<RawResetThePasswordForm {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/forgot-password/__specs__/SuccessView.spec.js
+++ b/src/components/pages/forgot-password/__specs__/SuccessView.spec.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import SuccessView from '../SuccessView'
 
 describe('src | components | pages | forgot-password | SuccessView', () => {
-  it('should match snapshot without token', () => {
+  it('should match the snapshot without token', () => {
     // given
     const props = { token: null }
 
@@ -11,11 +11,10 @@ describe('src | components | pages | forgot-password | SuccessView', () => {
     const wrapper = shallow(<SuccessView {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 
-  it('should match snapshot with token', () => {
+  it('should match the snapshot with token', () => {
     // given
     const props = { token: '1234567890' }
 
@@ -23,7 +22,6 @@ describe('src | components | pages | forgot-password | SuccessView', () => {
     const wrapper = shallow(<SuccessView {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/forgot-password/__specs__/__snapshots__/SuccessView.spec.js.snap
+++ b/src/components/pages/forgot-password/__specs__/__snapshots__/SuccessView.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | forgot-password | SuccessView should match snapshot with token 1`] = `
+exports[`src | components | pages | forgot-password | SuccessView should match the snapshot with token 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <SuccessView
@@ -299,7 +299,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | forgot-password | SuccessView should match snapshot without token 1`] = `
+exports[`src | components | pages | forgot-password | SuccessView should match the snapshot without token 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <SuccessView

--- a/src/components/pages/profile/__specs__/MonPassCulture.spec.jsx
+++ b/src/components/pages/profile/__specs__/MonPassCulture.spec.jsx
@@ -8,7 +8,7 @@ const digitalId = '#profile-digital-wallet-value'
 const physicalId = '#profile-physical-wallet-value'
 
 describe('src | components | MonPassCulture', () => {
-  it('should match snapshot with required props', () => {
+  it('should match the snapshot with required props', () => {
     // given
     const props = {
       currentUser: {
@@ -24,7 +24,6 @@ describe('src | components | MonPassCulture', () => {
     const wrapper = shallow(<MonPassCulture {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/profile/__specs__/__snapshots__/MonPassCulture.spec.jsx.snap
+++ b/src/components/pages/profile/__specs__/__snapshots__/MonPassCulture.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | MonPassCulture should match snapshot with required props 1`] = `
+exports[`src | components | MonPassCulture should match the snapshot with required props 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <MonPassCulture

--- a/src/components/pages/profile/forms/__specs__/ProfileForm.spec.js
+++ b/src/components/pages/profile/forms/__specs__/ProfileForm.spec.js
@@ -38,7 +38,6 @@ describe('src | components | pages | profile | forms | ProfileForm', () => {
     const wrapper = shallow(<ProfileForm {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/profile/forms/fields/__specs__/UserIdentifierField.spec.js
+++ b/src/components/pages/profile/forms/fields/__specs__/UserIdentifierField.spec.js
@@ -12,12 +12,11 @@ describe('src | components | pages | profile | forms | fields | UserIdentifierFi
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<UserIdentifierField {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/profile/forms/fields/__specs__/UserPasswordField.spec.js
+++ b/src/components/pages/profile/forms/fields/__specs__/UserPasswordField.spec.js
@@ -17,12 +17,11 @@ describe('src | components | pages | profile | forms | fields | UserPasswordFiel
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<UserPasswordField {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/profile/forms/fields/__specs__/__snapshots__/UserIdentifierField.spec.js.snap
+++ b/src/components/pages/profile/forms/fields/__specs__/__snapshots__/UserIdentifierField.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | profile | forms | fields | UserIdentifierField should match snapshot 1`] = `
+exports[`src | components | pages | profile | forms | fields | UserIdentifierField should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Unknown

--- a/src/components/pages/profile/forms/fields/__specs__/__snapshots__/UserPasswordField.spec.js.snap
+++ b/src/components/pages/profile/forms/fields/__specs__/__snapshots__/UserPasswordField.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | profile | forms | fields | UserPasswordField should match snapshot 1`] = `
+exports[`src | components | pages | profile | forms | fields | UserPasswordField should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <UserPasswordField

--- a/src/components/pages/search/FilterControls/__specs__/FilterByDates.spec.js
+++ b/src/components/pages/search/FilterControls/__specs__/FilterByDates.spec.js
@@ -41,7 +41,6 @@ describe('src | components | pages | search | FilterControls | FilterByDates', (
     const wrapper = shallow(<FilterByDates {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/FilterControls/__specs__/FilterByOfferTypes.spec.js
+++ b/src/components/pages/search/FilterControls/__specs__/FilterByOfferTypes.spec.js
@@ -43,7 +43,6 @@ describe('src | components | pages | search | FilterControls | FilterByOfferType
     const wrapper = shallow(<FilterByOfferTypes {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/FilterControls/__specs__/FilterControls.spec.jsx
+++ b/src/components/pages/search/FilterControls/__specs__/FilterControls.spec.jsx
@@ -35,7 +35,6 @@ describe('src | components | pages | search | FilterControls', () => {
     const wrapper = shallow(<FilterControls {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/NavByOfferType/__specs__/NavByOfferType.spec.jsx
+++ b/src/components/pages/search/NavByOfferType/__specs__/NavByOfferType.spec.jsx
@@ -22,7 +22,6 @@ describe('src | components | search | searchByType | NavByOfferType', () => {
     const wrapper = shallow(<NavByOfferType {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/Results/RecommendationItem/__specs__/RecommendationItem.spec.jsx
+++ b/src/components/pages/search/Results/RecommendationItem/__specs__/RecommendationItem.spec.jsx
@@ -33,7 +33,6 @@ describe('src | components | pages | search | Result | RecommendationItem', () =
     const wrapper = shallow(<RecommendationItem {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/Results/__specs__/Results.spec.js
+++ b/src/components/pages/search/Results/__specs__/Results.spec.js
@@ -31,7 +31,6 @@ describe('src | components | pages | search | Results', () => {
     const wrapper = shallow(<Results {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/__specs__/NavResultsHeader.spec.jsx
+++ b/src/components/pages/search/__specs__/NavResultsHeader.spec.jsx
@@ -20,7 +20,6 @@ describe('src | components | pages | search | NavResultsHeader', () => {
     const wrapper = shallow(<NavResultsHeader {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/__specs__/Search.spec.jsx
+++ b/src/components/pages/search/__specs__/Search.spec.jsx
@@ -94,12 +94,11 @@ describe('src | components | pages | Search', () => {
       }
     })
 
-    it('should match snapshot', () => {
+    it('should match the snapshot', () => {
       // when
       const wrapper = shallow(<Search {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
   })

--- a/src/components/pages/search/__specs__/SearchPicture.spec.js
+++ b/src/components/pages/search/__specs__/SearchPicture.spec.js
@@ -17,7 +17,6 @@ describe('src | components | pages | search | SearchPicture', () => {
     const wrapper = shallow(<SearchPicture {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/search/__specs__/__snapshots__/Search.spec.jsx.snap
+++ b/src/components/pages/search/__specs__/__snapshots__/Search.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Search snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Search snapshot should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Search

--- a/src/components/pages/signin/__specs__/FormHeader.spec.js
+++ b/src/components/pages/signin/__specs__/FormHeader.spec.js
@@ -4,17 +4,14 @@ import { shallow } from 'enzyme'
 import FormHeader from '../FormHeader'
 
 describe('src | components | pages | signin | FormHeader', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {}
+  it('should match the snapshot', () => {
+    // given
+    const props = {}
 
-      // when
-      const wrapper = shallow(<FormHeader {...props} />)
+    // when
+    const wrapper = shallow(<FormHeader {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/signin/__specs__/FormInputs.spec.js
+++ b/src/components/pages/signin/__specs__/FormInputs.spec.js
@@ -4,17 +4,14 @@ import { shallow } from 'enzyme'
 import FormInputs from '../FormInputs'
 
 describe('src | components | pages | signin | FormInputs', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {}
+  it('should match the snapshot', () => {
+    // given
+    const props = {}
 
-      // when
-      const wrapper = shallow(<FormInputs {...props} />)
+    // when
+    const wrapper = shallow(<FormInputs {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/signin/__specs__/Signin.spec.js
+++ b/src/components/pages/signin/__specs__/Signin.spec.js
@@ -19,7 +19,6 @@ describe('src | components | pages | signin | Signin', () => {
     const wrapper = shallow(<Signin {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/signin/__specs__/SigninContainer.spec.js
+++ b/src/components/pages/signin/__specs__/SigninContainer.spec.js
@@ -4,17 +4,14 @@ import React from 'react'
 import SigninContainer from '../SigninContainer'
 
 describe('src | components | pages | signin | Index', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {}
+  it('should match the snapshot', () => {
+    // given
+    const props = {}
 
-      // when
-      const wrapper = shallow(<SigninContainer {...props} />)
+    // when
+    const wrapper = shallow(<SigninContainer {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/signin/__specs__/__snapshots__/FormHeader.spec.js.snap
+++ b/src/components/pages/signin/__specs__/__snapshots__/FormHeader.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | signin | FormHeader snapshot should match snapshot 1`] = `
+exports[`src | components | pages | signin | FormHeader should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <FormHeader />,

--- a/src/components/pages/signin/__specs__/__snapshots__/FormInputs.spec.js.snap
+++ b/src/components/pages/signin/__specs__/__snapshots__/FormInputs.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | signin | FormInputs snapshot should match snapshot 1`] = `
+exports[`src | components | pages | signin | FormInputs should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <FormInputs />,

--- a/src/components/pages/signin/__specs__/__snapshots__/SigninContainer.spec.js.snap
+++ b/src/components/pages/signin/__specs__/__snapshots__/SigninContainer.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | signin | Index snapshot should match snapshot 1`] = `
+exports[`src | components | pages | signin | Index should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <withRouter(_withQueryRouter) />,

--- a/src/components/pages/typeform/__specs__/TypeForm.spec.js
+++ b/src/components/pages/typeform/__specs__/TypeForm.spec.js
@@ -9,7 +9,7 @@ const history = createBrowserHistory()
 history.push('/typeform')
 
 describe('src | components | pages | typeform | TypeForm', () => {
-  it('should match snapshots with required props', () => {
+  it('should match the snapshots with required props', () => {
     // given
     const props = {
       flagUserHasFilledTypeform: jest.fn(),
@@ -27,7 +27,6 @@ describe('src | components | pages | typeform | TypeForm', () => {
     )
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/typeform/__specs__/__snapshots__/TypeForm.spec.js.snap
+++ b/src/components/pages/typeform/__specs__/__snapshots__/TypeForm.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | typeform | TypeForm should match snapshots with required props 1`] = `
+exports[`src | components | pages | typeform | TypeForm should match the snapshots with required props 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <MemoryRouter

--- a/src/components/router/__specs__/FeaturedRoute.spec.jsx
+++ b/src/components/router/__specs__/FeaturedRoute.spec.jsx
@@ -21,7 +21,6 @@ describe('src | components | router | FeaturedRoute', () => {
     const wrapper = shallow(<FeaturedRoute {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/selectors/__specs__/selectBookingById.spec.js
+++ b/src/selectors/__specs__/selectBookingById.spec.js
@@ -28,7 +28,6 @@ describe('src | selectors | selectBookingById', () => {
     const result = selectBookingById(state, 'bar')
 
     // then
-    expect(result).toBeDefined()
     expect(result).toStrictEqual({ id: 'bar' })
     expect(result).toBe(state.data.bookings[1])
   })

--- a/src/selectors/__specs__/selectMediationById.spec.js
+++ b/src/selectors/__specs__/selectMediationById.spec.js
@@ -28,7 +28,6 @@ describe('src | selectors | selectMediationById', () => {
     const result = selectMediationById(state, 'bar')
 
     // then
-    expect(result).toBeDefined()
     expect(result).toStrictEqual({ id: 'bar' })
     expect(result).toBe(state.data.mediations[1])
   })

--- a/src/selectors/__specs__/selectOfferById.spec.js
+++ b/src/selectors/__specs__/selectOfferById.spec.js
@@ -28,7 +28,6 @@ describe('src | selectors | selectOfferById', () => {
     const result = selectOfferById(state, 'bar')
 
     // then
-    expect(result).toBeDefined()
     expect(result).toStrictEqual({ id: 'bar' })
     expect(result).toBe(state.data.offers[1])
   })

--- a/src/selectors/__specs__/selectRecommendationById.spec.js
+++ b/src/selectors/__specs__/selectRecommendationById.spec.js
@@ -28,7 +28,6 @@ describe('src | selectors | selectRecommendationById', () => {
     const result = selectRecommendationById(state, 'bar')
 
     // then
-    expect(result).toBeDefined()
     expect(result).toStrictEqual({ id: 'bar' })
     expect(result).toBe(state.data.recommendations[1])
   })


### PR DESCRIPTION
- Suppression de `toBeDefined` dans les tests quand ce n'est pas nécessaire (tel que décider en rétro tech) ;
- Renommage de `should match snapshot` en `should match the snapshot` (d'où le fait que les snapshots ont changés) ;
- Suppression de `describe('snapshot', () => {` quand inutile ;