### PR TITLE
(pC-2253) fix calendar date testcafe

### DIFF
--- a/src/components/forms/inputs/DatePickerField/DatePickerField.jsx
+++ b/src/components/forms/inputs/DatePickerField/DatePickerField.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import DatePicker from 'react-datepicker'
 import ReactDOM from 'react-dom'
-import { withSizes } from 'react-sizes'
 
 import DatePickerCustomField from './DatePickerCustomField/DatePickerCustomField'
 import InputLabel from '../../InputLabel'
@@ -27,6 +26,7 @@ const DatePickerField = ({
   readOnly,
   required,
   selected,
+  withPortal,
   // NOTE -> Autres props du react-datepicker passées en option
   // github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md
   ...rest
@@ -38,6 +38,7 @@ const DatePickerField = ({
   if (!hideToday) {
     moreProps.todayButton = `Aujourd'hui`
   }
+
   const isClearable = !readOnly && clearable
   const inputName = id || name
   return (
@@ -63,6 +64,7 @@ const DatePickerField = ({
             readOnly={readOnly}
             selected={selected}
             shouldCloseOnSelect
+            withPortal={withPortal}
           />
         </div>
       </label>
@@ -79,12 +81,12 @@ DatePickerField.defaultProps = {
   id: null,
   label: null,
   locale: 'fr',
-  placeholder: '-',
+  placeholder: '',
   popperRefContainer: null,
   readOnly: false,
   required: false,
   selected: null,
-  withPortal: false,
+  withPortal: true,
 }
 
 DatePickerField.propTypes = {
@@ -106,8 +108,4 @@ DatePickerField.propTypes = {
   withPortal: PropTypes.bool,
 }
 
-const mapSizesToProps = ({ height }) => ({
-  withPortal: height <= 650,
-})
-
-export default withSizes(mapSizesToProps)(DatePickerField)
+export default DatePickerField

--- a/src/components/forms/inputs/DatePickerField/DatePickerField.jsx
+++ b/src/components/forms/inputs/DatePickerField/DatePickerField.jsx
@@ -81,7 +81,7 @@ DatePickerField.defaultProps = {
   id: null,
   label: null,
   locale: 'fr',
-  placeholder: '',
+  placeholder: '-',
   popperRefContainer: null,
   readOnly: false,
   required: false,

--- a/src/components/layout/Booking/Booking.jsx
+++ b/src/components/layout/Booking/Booking.jsx
@@ -192,7 +192,7 @@ class Booking extends PureComponent {
     let price
     let stockId
     const isReadOnly = bookables.length === 1
-    if (defaultBookable) {
+    if (defaultBookable && isReadOnly) {
       date = defaultBookable.beginningDatetime && moment(defaultBookable.beginningDatetime)
       price = priceIsDefined(defaultBookable.price) ? defaultBookable.price : null
       stockId = defaultBookable.id

--- a/src/components/layout/Booking/BookingForm/BookingFormContent/BookingFormContent.jsx
+++ b/src/components/layout/Booking/BookingForm/BookingFormContent/BookingFormContent.jsx
@@ -37,7 +37,6 @@ class BookingFormContent extends Component {
     const calendarDates = getCalendarProvider(values)
     const calendarLabel = calendarDates.length === 1 ? '' : 'Choisissez une date'
     const dateFormat = 'DD MMMM YYYY'
-
     return (
       <DatePickerField
         {...input}
@@ -50,7 +49,6 @@ class BookingFormContent extends Component {
         label={calendarLabel}
         name="date"
         onChange={this.handleChangeAndRemoveCalendar(input)}
-        popperPlacement="bottom"
         readOnly={calendarDates.length === 1}
         selected={value}
       />
@@ -62,6 +60,7 @@ class BookingFormContent extends Component {
     const { price } = values
     const bookableTimes = parseHoursByStockId(values)
     const hasOneBookableTime = bookableTimes.length === 1
+    const hasBookableTimes = bookableTimes.length > 0
     const hourLabel = hasOneBookableTime ? '' : 'Choisissez une heure'
 
     return (
@@ -78,7 +77,7 @@ class BookingFormContent extends Component {
               name="date"
               render={this.renderBookingDatePickerField}
             />
-            {bookableTimes && (
+            {bookableTimes && hasBookableTimes && (
               <SelectField
                 className="text-center"
                 id="booking-form-time-picker-field"

--- a/src/components/layout/Booking/BookingForm/BookingFormContent/__specs__/BookingFormContent.spec.jsx
+++ b/src/components/layout/Booking/BookingForm/BookingFormContent/__specs__/BookingFormContent.spec.jsx
@@ -1,4 +1,5 @@
 import { shallow } from 'enzyme'
+import moment from 'moment'
 import React from 'react'
 import { Field } from 'react-final-form'
 
@@ -21,8 +22,8 @@ describe('src | components | layout | Booking | BookingForm | BookingFormContent
       onChange: jest.fn(),
       values: {
         bookables: [],
-        date: '2019-01-01',
-        price: 12,
+        date: null,
+        price: null,
       },
     }
   })
@@ -79,7 +80,34 @@ describe('src | components | layout | Booking | BookingForm | BookingFormContent
         expect(field.prop('render')).toStrictEqual(expect.any(Function))
       })
 
-      it('should render a SelectField component with the right props when no date has been selected', () => {
+      it('should not render a SelectField component when no date has been selected', () => {
+        // when
+        const wrapper = shallow(<BookingFormContent {...props} />)
+
+        // then
+        const selectField = wrapper.find(SelectField)
+        expect(selectField).toHaveLength(0)
+      })
+
+      it('should render a SelectField component with the right props when date has been selected', () => {
+        // given
+        const date = moment().add(3, 'days')
+        props.values = {
+          bookables: [
+            {
+              beginningDatetime: date,
+              id: 'AE',
+              price: 12,
+            },
+            {
+              beginningDatetime: date,
+              id: 'AF',
+              price: 13,
+            },
+          ],
+          date,
+        }
+
         // when
         const wrapper = shallow(<BookingFormContent {...props} />)
 
@@ -93,7 +121,16 @@ describe('src | components | layout | Booking | BookingForm | BookingFormContent
           label: 'Choisissez une heure',
           name: 'time',
           placeholder: 'Heure et prix',
-          options: [],
+          options: [
+            {
+              id: 'AE',
+              label: `${date.format('HH:mm')} - 12\u00A0€`,
+            },
+            {
+              id: 'AF',
+              label: `${date.format('HH:mm')} - 13\u00A0€`,
+            },
+          ],
           readOnly: false,
           required: false,
         })
@@ -103,6 +140,11 @@ describe('src | components | layout | Booking | BookingForm | BookingFormContent
     describe('when not isEvent', () => {
       it('should render two blocks with the proper information', () => {
         // given
+        props.values = {
+          bookables: [],
+          date: '2019-01-01',
+          price: 12,
+        }
         props.isEvent = false
 
         // when

--- a/src/components/layout/Booking/BookingForm/BookingFormContent/__specs__/__snapshots__/BookingFormContent.spec.jsx.snap
+++ b/src/components/layout/Booking/BookingForm/BookingFormContent/__specs__/__snapshots__/BookingFormContent.spec.jsx.snap
@@ -14,8 +14,8 @@ ShallowWrapper {
     values={
       Object {
         "bookables": Array [],
-        "date": "2019-01-01",
-        "price": 12,
+        "date": null,
+        "price": null,
       }
     }
   />,
@@ -46,7 +46,7 @@ ShallowWrapper {
           <span
             className="is-block"
           >
-            cette offre pour 12 €.
+            cette offre pour null €.
           </span>
         </p>,
       ],
@@ -71,7 +71,7 @@ ShallowWrapper {
             <span
               className="is-block"
             >
-              cette offre pour 12 €.
+              cette offre pour null €.
             </span>,
           ],
           "className": "text-center fs22",
@@ -95,11 +95,11 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": "cette offre pour 12 €.",
+              "children": "cette offre pour null €.",
               "className": "is-block",
             },
             "ref": null,
-            "rendered": "cette offre pour 12 €.",
+            "rendered": "cette offre pour null €.",
             "type": "span",
           },
         ],
@@ -127,7 +127,7 @@ ShallowWrapper {
             <span
               className="is-block"
             >
-              cette offre pour 12 €.
+              cette offre pour null €.
             </span>
           </p>,
         ],
@@ -152,7 +152,7 @@ ShallowWrapper {
               <span
                 className="is-block"
               >
-                cette offre pour 12 €.
+                cette offre pour null €.
               </span>,
             ],
             "className": "text-center fs22",
@@ -176,11 +176,11 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "children": "cette offre pour 12 €.",
+                "children": "cette offre pour null €.",
                 "className": "is-block",
               },
               "ref": null,
-              "rendered": "cette offre pour 12 €.",
+              "rendered": "cette offre pour null €.",
               "type": "span",
             },
           ],

--- a/src/components/layout/Booking/utils/parseHoursByStockId.js
+++ b/src/components/layout/Booking/utils/parseHoursByStockId.js
@@ -9,6 +9,7 @@ const parseHoursByStockId = (allFormValues, format = 'HH:mm') => {
     allFormValues.bookables.length > 0 &&
     allFormValues.date &&
     moment.isMoment(allFormValues.date)
+
   if (!hasBookableDates) return []
   const { date, bookables } = allFormValues
 

--- a/src/components/pages/search/FilterControls/FilterByDates.jsx
+++ b/src/components/pages/search/FilterControls/FilterByDates.jsx
@@ -99,6 +99,7 @@ class FilterByDates extends PureComponent {
               minDate={new Date()}
               name="pick-by-date-filter"
               onChange={this.handleOnChangePickedDate}
+              placeholder="Par date"
               popperRefContainer={this.datepickerPopper}
               selected={pickedDate}
             />

--- a/src/components/pages/search/FilterControls/__specs__/__snapshots__/FilterByDates.spec.jsx.snap
+++ b/src/components/pages/search/FilterControls/__specs__/__snapshots__/FilterByDates.spec.jsx.snap
@@ -120,17 +120,28 @@ ShallowWrapper {
                 Plus de 5 jours
               </span>
             </label>
-            <withSizes(DatePickerField)
+            <DatePickerField
               className="item fs19 py5 px7"
+              clearable={true}
+              dateFormat="DD/MM/YYYY"
+              hideToday={false}
+              icon={null}
+              id={null}
+              label={null}
+              locale="fr"
               minDate={2019-06-02T12:41:33.680Z}
               name="pick-by-date-filter"
               onChange={[Function]}
+              placeholder="Par date"
               popperRefContainer={
                 Object {
                   "current": null,
                 }
               }
+              readOnly={false}
+              required={false}
               selected={null}
+              withPortal={true}
             />
           </div>
         </div>,
@@ -232,17 +243,28 @@ ShallowWrapper {
                 Plus de 5 jours
               </span>
             </label>
-            <withSizes(DatePickerField)
+            <DatePickerField
               className="item fs19 py5 px7"
+              clearable={true}
+              dateFormat="DD/MM/YYYY"
+              hideToday={false}
+              icon={null}
+              id={null}
+              label={null}
+              locale="fr"
               minDate={2019-06-02T12:41:33.680Z}
               name="pick-by-date-filter"
               onChange={[Function]}
+              placeholder="Par date"
               popperRefContainer={
                 Object {
                   "current": null,
                 }
               }
+              readOnly={false}
+              required={false}
               selected={null}
+              withPortal={true}
             />
           </div>,
           "className": "pc-scroll-horizontal is-relative pb18",
@@ -322,17 +344,28 @@ ShallowWrapper {
                   </span>
                 </label>,
               ],
-              <withSizes(DatePickerField)
+              <DatePickerField
                 className="item fs19 py5 px7"
+                clearable={true}
+                dateFormat="DD/MM/YYYY"
+                hideToday={false}
+                icon={null}
+                id={null}
+                label={null}
+                locale="fr"
                 minDate={2019-06-02T12:41:33.680Z}
                 name="pick-by-date-filter"
                 onChange={[Function]}
+                placeholder="Par date"
                 popperRefContainer={
                   Object {
                     "current": null,
                   }
                 }
+                readOnly={false}
+                required={false}
                 selected={null}
+                withPortal={true}
               />,
             ],
             "className": "pc-list flex-columns",
@@ -576,16 +609,27 @@ ShallowWrapper {
             Object {
               "instance": null,
               "key": undefined,
-              "nodeType": "class",
+              "nodeType": "function",
               "props": Object {
                 "className": "item fs19 py5 px7",
+                "clearable": true,
+                "dateFormat": "DD/MM/YYYY",
+                "hideToday": false,
+                "icon": null,
+                "id": null,
+                "label": null,
+                "locale": "fr",
                 "minDate": 2019-06-02T12:41:33.680Z,
                 "name": "pick-by-date-filter",
                 "onChange": [Function],
+                "placeholder": "Par date",
                 "popperRefContainer": Object {
                   "current": null,
                 },
+                "readOnly": false,
+                "required": false,
                 "selected": null,
+                "withPortal": true,
               },
               "ref": null,
               "rendered": null,
@@ -707,17 +751,28 @@ ShallowWrapper {
                   Plus de 5 jours
                 </span>
               </label>
-              <withSizes(DatePickerField)
+              <DatePickerField
                 className="item fs19 py5 px7"
+                clearable={true}
+                dateFormat="DD/MM/YYYY"
+                hideToday={false}
+                icon={null}
+                id={null}
+                label={null}
+                locale="fr"
                 minDate={2019-06-02T12:41:33.680Z}
                 name="pick-by-date-filter"
                 onChange={[Function]}
+                placeholder="Par date"
                 popperRefContainer={
                   Object {
                     "current": null,
                   }
                 }
+                readOnly={false}
+                required={false}
                 selected={null}
+                withPortal={true}
               />
             </div>
           </div>,
@@ -819,17 +874,28 @@ ShallowWrapper {
                   Plus de 5 jours
                 </span>
               </label>
-              <withSizes(DatePickerField)
+              <DatePickerField
                 className="item fs19 py5 px7"
+                clearable={true}
+                dateFormat="DD/MM/YYYY"
+                hideToday={false}
+                icon={null}
+                id={null}
+                label={null}
+                locale="fr"
                 minDate={2019-06-02T12:41:33.680Z}
                 name="pick-by-date-filter"
                 onChange={[Function]}
+                placeholder="Par date"
                 popperRefContainer={
                   Object {
                     "current": null,
                   }
                 }
+                readOnly={false}
+                required={false}
                 selected={null}
+                withPortal={true}
               />
             </div>,
             "className": "pc-scroll-horizontal is-relative pb18",
@@ -909,17 +975,28 @@ ShallowWrapper {
                     </span>
                   </label>,
                 ],
-                <withSizes(DatePickerField)
+                <DatePickerField
                   className="item fs19 py5 px7"
+                  clearable={true}
+                  dateFormat="DD/MM/YYYY"
+                  hideToday={false}
+                  icon={null}
+                  id={null}
+                  label={null}
+                  locale="fr"
                   minDate={2019-06-02T12:41:33.680Z}
                   name="pick-by-date-filter"
                   onChange={[Function]}
+                  placeholder="Par date"
                   popperRefContainer={
                     Object {
                       "current": null,
                     }
                   }
+                  readOnly={false}
+                  required={false}
                   selected={null}
+                  withPortal={true}
                 />,
               ],
               "className": "pc-list flex-columns",
@@ -1163,16 +1240,27 @@ ShallowWrapper {
               Object {
                 "instance": null,
                 "key": undefined,
-                "nodeType": "class",
+                "nodeType": "function",
                 "props": Object {
                   "className": "item fs19 py5 px7",
+                  "clearable": true,
+                  "dateFormat": "DD/MM/YYYY",
+                  "hideToday": false,
+                  "icon": null,
+                  "id": null,
+                  "label": null,
+                  "locale": "fr",
                   "minDate": 2019-06-02T12:41:33.680Z,
                   "name": "pick-by-date-filter",
                   "onChange": [Function],
+                  "placeholder": "Par date",
                   "popperRefContainer": Object {
                     "current": null,
                   },
+                  "readOnly": false,
+                  "required": false,
                   "selected": null,
+                  "withPortal": true,
                 },
                 "ref": null,
                 "rendered": null,

--- a/src/styles/components/layout/Booking/index.scss
+++ b/src/styles/components/layout/Booking/index.scss
@@ -36,14 +36,12 @@
 
   .pc-final-form-datepicker-input {
     @extend .py7;
-    @extend .px18;
     @extend .fs20;
     @extend .flex-1;
     @extend .is-bold;
     @extend .is-block;
     @extend .no-border;
     @extend .no-outline;
-    @extend .text-center;
 
     color: $black !important;
     cursor: pointer;

--- a/src/styles/components/pages/search/searchFilters/_SearchFilter.scss
+++ b/src/styles/components/pages/search/searchFilters/_SearchFilter.scss
@@ -97,7 +97,7 @@
 
   /* ----- Clear Button du filtre par date ----- */
   .react-datepicker__close-icon {
-    top: 0;
+    top: 5px;
     right: 0;
     width: $size;
     height: $size;
@@ -109,9 +109,26 @@
     }
   }
 
-  .react-datepicker__input-container_wrapper::after {
-    top: 0;
-    font-size: $fontSize;
+  .react-datepicker__input-container_wrapper {
+    padding-left: 1rem;
+
+    &::after {
+      font-size: $fontSize;
+      top: 0;
+    }
+
+    input {
+      color: inherit;
+      font-size: inherit;
+      font-weight: 300;
+      padding-left: 0;
+      padding-top: 0;
+      width: 125px;
+    }
+
+    &.selected {
+      padding-left: 0;
+    }
   }
 }
 

--- a/src/styles/global/_datepicker.scss
+++ b/src/styles/global/_datepicker.scss
@@ -45,11 +45,34 @@
     width: rem(36px);
     height: rem(36px);
     line-height: rem(36px);
+
+    &:hover {
+      background-color: $grey-light;
+    }
   }
 
-  .react-datepicker__day--selected,
+  .react-datepicker__day--disabled {
+    &:hover {
+      background-color: $white;
+    }
+  }
+
   .react-datepicker__day--keyboard-selected {
+    background-color: $white;
+    color: $dark;
+
+    &:hover {
+      background-color: $grey-light;
+    }
+  }
+
+  .react-datepicker__day--selected {
     background-color: $primary;
+
+    &.react-datepicker__day--keyboard-selected {
+      background-color: $primary;
+      color: $white;
+    }
   }
 }
 

--- a/src/styles/global/_forms.scss
+++ b/src/styles/global/_forms.scss
@@ -197,9 +197,11 @@
   .calendar-icon {
     padding: 0.25rem;
     padding-right: 1rem;
+    vertical-align: middle;
   }
 
   input {
+    padding-left: 1.125rem;
     padding-top: 0.25rem;
     text-align: center;
 
@@ -226,14 +228,22 @@
       font-size: 19px;
       font-weight: 300;
     }
+
+    &.read-only {
+      .pc-final-form-datepicker-input {
+        background-color: #F5F5F5;
+      }
+    }
+
+    &.selected {
+      &::after {
+        display: none;
+        visibility: hidden;
+      }
+
+      input {
+        text-align: right;
+      }
+    }
   }
-}
-
-.react-datepicker__input-container_wrapper.read-only .pc-final-form-datepicker-input {
-  background-color: #F5F5F5;
-}
-
-.react-datepicker__input-container_wrapper.selected::after {
-  display: none;
-  visibility: hidden;
 }

--- a/src/styles/global/_forms.scss
+++ b/src/styles/global/_forms.scss
@@ -188,7 +188,6 @@
     $size: rem(30px);
 
     color: $primary;
-    content: '\6b';
     font-size: rem(30px);
     position: absolute;
     right: 6px;
@@ -198,6 +197,35 @@
   .calendar-icon {
     padding: 0.25rem;
     padding-right: 1rem;
+  }
+
+  input {
+    padding-top: 0.25rem;
+    text-align: center;
+
+    &::-webkit-input-placeholder {
+      color: inherit;
+      font-size: 19px;
+      font-weight: 300;
+    }
+
+    &::-moz-placeholder {
+      color: inherit;
+      font-size: 19px;
+      font-weight: 300;
+    }
+
+    &:-ms-input-placeholder {
+      color: inherit;
+      font-size: 19px;
+      font-weight: 300;
+    }
+
+    &:-moz-placeholder {
+      color: inherit;
+      font-size: 19px;
+      font-weight: 300;
+    }
   }
 }
 

--- a/testcafe/04_verso.js
+++ b/testcafe/04_verso.js
@@ -151,6 +151,7 @@ test("Parcours complet de réservation d'une offre event à date unique", async 
   // when
   await t.click(openMenuFromVerso).wait(500)
   previousWalletValue = await getMenuWalletValue()
+
   await t
     .expect(previousWalletValue)
     .gt(0)
@@ -158,8 +159,6 @@ test("Parcours complet de réservation d'une offre event à date unique", async 
     .click(bookOfferButton)
     .click(dateSelectBox)
     .click(selectableDates.nth(0))
-
-  await t
     .click(sendBookingButton)
     .expect(bookingErrorReasons.count)
     .eql(0)


### PR DESCRIPTION
Le bug venait du fait qu'en chrome:headless, le calendrier est affiché en vision withPortal. Et dans ce cas precis: cliquer sur la selectedDate.nth(0) dans testcafé ne déclenche pas le close on select du calendrier (car en fait selectedDate.nth(0) est déjà la data préselectionnée).

Du coup:
- Premierement, on passe tout quand en withPortal car la vision sans est moche et depasse du cadre
- on fait en sorte qu'il n'y ait pas de date preselectionnée au montage du calendrier. Comme ça  cliquer selectedDate.nth(0) revient bien à choisir une date et declenche la fermeture du calendrier.
- il faut faire un petit hack de style sur .--keyboard-selected des dates, car quand le calendrier n'a pas de date selectionné, il affiche en style "selected" quand meme la premiere date de l'array includedDates.


