### PR TITLE
add componentDidMount to Results

### DIFF
--- a/src/components/pages/search/Results/Results.jsx
+++ b/src/components/pages/search/Results/Results.jsx
@@ -19,6 +19,14 @@ class Results extends PureComponent {
     }
   }
 
+  componentDidMount() {
+    const { items } = this.props
+
+    if (items.length) {
+      this.handleSetHasReceivedFirstSuccessData()
+    }
+  }
+
   componentDidUpdate(prevProps) {
     const { items } = this.props
 


### PR DESCRIPTION
A cause de ce commit https://github.com/betagouv/fetch-normalize-data/commit/57462fcf2274d2e530112b0efec3ce4cca777c59.
Le `dispatch(successData(payload, config))` a été intervertie.