### PR TITLE
(FIX-locale-date) Fix locale date partial support prior to Node 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "eslint-plugin-react": "^7.16.0",
     "file-loader": "^4.2.0",
     "fs-extra": "^8.1.0",
+    "full-icu": "^1.3.0",
     "html-webpack-plugin": "4.0.0-alpha.2",
     "husky": "^3.0.9",
     "jest": "23.6.0",
@@ -120,7 +121,7 @@
     "lint:js:fix": "yarn lint:js --fix",
     "start": "node scripts/start.js",
     "test:cafe": "testcafe --assertion-timeout 8000 --selector-timeout 20000 -S -s testcafe_screenshots 'chrome:headless' testcafe",
-    "test:unit": "jest --env=jsdom"
+    "test:unit": "NODE_ICU_DATA=node_modules/full-icu jest --env=jsdom"
   },
   "husky": {
     "hooks": {

--- a/src/components/layout/Teaser/__specs__/TeaserContainer.spec.js
+++ b/src/components/layout/Teaser/__specs__/TeaserContainer.spec.js
@@ -94,7 +94,7 @@ describe('src | components | layout | Teaser | TeaserContainer', () => {
 
         // then
         expect(props).toStrictEqual({
-          date: 'du 7/21/2000 au 8/21/2030',
+          date: 'du 21/07/2000 au 21/08/2030',
           detailsUrl: '//details/o1/vide',
           handleToggleTeaser: expect.any(Function),
           humanizeRelativeDistance: '10 km',
@@ -124,7 +124,7 @@ describe('src | components | layout | Teaser | TeaserContainer', () => {
 
         // then
         expect(props).toStrictEqual({
-          date: 'du 7/21/2000 au 8/21/2030',
+          date: 'du 21/07/2000 au 21/08/2030',
           detailsUrl: '//details/o1/vide',
           handleToggleTeaser: expect.any(Function),
           humanizeRelativeDistance: '10 km',

--- a/src/components/pages/profile/RemainingCredit/__specs__/RemainingCredit.spec.jsx
+++ b/src/components/pages/profile/RemainingCredit/__specs__/RemainingCredit.spec.jsx
@@ -132,7 +132,7 @@ describe('components | RemainingCredit', () => {
 
       // Then
       const textWithEndValidityDate = wrapper.find('.rc-end-validity-date').text()
-      expect(textWithEndValidityDate).toBe('Votre crédit est valable jusqu’au September 10, 2021.')
+      expect(textWithEndValidityDate).toBe('Votre crédit est valable jusqu’au 10 septembre 2021.')
     })
 
     it('should not render end validity date when user has no deposit', () => {

--- a/src/components/pages/search-algolia/Result/__specs__/Result.spec.jsx
+++ b/src/components/pages/search-algolia/Result/__specs__/Result.spec.jsx
@@ -43,7 +43,7 @@ describe('components | Result', () => {
     const offerName = wrapper.findWhere(node => node.text() === 'Les fleurs du mal').first()
     const offerLabel = wrapper.findWhere(node => node.text() === 'Livre').first()
     const offerDateRange = wrapper
-      .findWhere(node => node.text() === 'du 1/1/2019 au 1/30/2019')
+      .findWhere(node => node.text() === 'du 01/01/2019 au 30/01/2019')
       .first()
     const offerDistance = wrapper.findWhere(node => node.text() === '5879 km').first()
     const offerMediation = wrapper.find('img')

--- a/src/utils/date/__specs__/date.spec.js
+++ b/src/utils/date/__specs__/date.spec.js
@@ -10,7 +10,7 @@ describe('src | utils | date', () => {
       const formattedDate = computeEndValidityDate(date)
 
       // then
-      expect(formattedDate).toBe('September 10, 2021')
+      expect(formattedDate).toBe('10 septembre 2021')
     })
   })
 
@@ -40,8 +40,7 @@ describe('src | utils | date', () => {
         const result = formatRecommendationDates(departementCode, dateRange)
 
         // then
-        // https://github.com/nodejs/node-v0.x-archive/issues/4689
-        expect(result).toBe('du 10/25/2018 au 10/26/2018')
+        expect(result).toBe('du 25/10/2018 au 26/10/2018')
       })
     })
 
@@ -55,8 +54,7 @@ describe('src | utils | date', () => {
         const result = formatRecommendationDates(departementCode, dateRange)
 
         // then
-        // https://github.com/nodejs/node-v0.x-archive/issues/4689
-        expect(result).toBe('du 10/25/2018 au 10/26/2018')
+        expect(result).toBe('du 25/10/2018 au 26/10/2018')
       })
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4672,6 +4672,11 @@ fstream@^1.0.0, fstream@^1.0.12:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+full-icu@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/full-icu/-/full-icu-1.3.0.tgz#1fb4d60050103ad9dcf53735c000e4a03d80c574"
+  integrity sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"


### PR DESCRIPTION
NodeJS builds prior to Node 13 is shipped with small ICU support, which means Node takes system-wide ICU configuration for some features, like toLocaleDateString that we are using (https://nodejs.org/dist/latest-v12.x/docs/api/all.html#intl_build_with_a_pre_installed_icu_system_icu). MacOS is also shipped with small ICU support, so it doesn't fully support this feature. Other linux-based systems use different ICU configurations so we never get the same date output regarding the OS where tests are executed. Web browsers, however, implements full ICU support so the running production version is not concerned, it is just for development and tests execution.