### PR TITLE
(pC-2857): Use new recommandations system from API (with materialized view).

### DIFF
--- a/src/components/layout/Menu/SignoutButton/SignoutButtonContainer.js
+++ b/src/components/layout/Menu/SignoutButton/SignoutButtonContainer.js
@@ -3,7 +3,7 @@ import { requestData, reinitializeData } from 'redux-thunk-data'
 
 import SignoutButton from './SignoutButton'
 import { toggleMainMenu } from '../../../../reducers/menu'
-import { updatePage, updateSeed, updateSeedLastRequestTimestamp } from '../../../../reducers/pagination'
+import { updateSeedLastRequestTimestamp } from '../../../../reducers/pagination'
 
 export const mapDispatchToProps = dispatch => ({
   onSignOutClick: ({ history, readRecommendations }) => () => {
@@ -19,15 +19,7 @@ export const mapDispatchToProps = dispatch => ({
           handleSuccess: handleSuccessAfterSignOut,
         })
       )
-      dispatch(
-        updatePage(1)
-      )
-      dispatch(
-        updateSeed(Math.random())
-      )
-      dispatch(
-        updateSeedLastRequestTimestamp(Date.now())
-      )
+      dispatch(updateSeedLastRequestTimestamp(Date.now()))
     }
 
     if (!readRecommendations || readRecommendations.length === 0) {

--- a/src/components/layout/Menu/SignoutButton/__specs__/SignoutButtonContainer.spec.js
+++ b/src/components/layout/Menu/SignoutButton/__specs__/SignoutButtonContainer.spec.js
@@ -14,13 +14,8 @@ jest.mock('redux-thunk-data', () => ({
 describe('src | components | layout | Menu | SignoutButton | SignoutButtonContainer', () => {
   describe('mapDispatchToProps()', () => {
     describe('onSignOutClick()', () => {
-      it('should land to /connexion, close the menu, reset readRecommendations and pagination in store', () => {
+      it('should land to /connexion, close the menu, reset readRecommendations', () => {
         // given
-        const initialPagination = {
-          page: 4,
-          seed: 0.1,
-          seedLastRequestTimestamp: 11111111112,
-        }
         const { store } = configureStore({
           data: {
             bookings: [{ id: 'b1' }],
@@ -28,7 +23,9 @@ describe('src | components | layout | Menu | SignoutButton | SignoutButtonContai
             users: [{ id: 'u1' }],
           },
           menu: true,
-          pagination: initialPagination,
+          pagination: {
+            seedLastRequestTimestamp: 11111111112,
+          },
         })
         const history = createBrowserHistory()
         const readRecommendations = [
@@ -66,11 +63,7 @@ describe('src | components | layout | Menu | SignoutButton | SignoutButtonContai
         })
         expect(data.readRecommendations).toHaveLength(0)
         expect(history.location.pathname).toBe('/connexion')
-        expect(pagination.page).toBe(1)
-        expect(pagination.seed).not.toStrictEqual(initialPagination.seed)
-        expect(pagination.seedLastRequestTimestamp).not.toStrictEqual(
-          initialPagination.seedLastRequestTimestamp
-        )
+        expect(pagination.seedLastRequestTimestamp).not.toBe(11111111112)
       })
     })
   })

--- a/src/components/layout/Menu/utils/__specs__/getMenuItems.spec.js
+++ b/src/components/layout/Menu/utils/__specs__/getMenuItems.spec.js
@@ -1,4 +1,5 @@
 import DiscoveryContainer from '../../../../pages/discovery/DiscoveryContainer'
+import DiscoveryContainerV2 from '../../../../pages/discovery/DiscoveryContainerV2'
 import MyFavoritesContainer from '../../../../pages/my-favorites/MyFavoritesContainer'
 import MyBookingsContainer from '../../../../pages/my-bookings/MyBookingsContainer'
 import ProfileContainer from '../../../../pages/profile/ProfileContainer'
@@ -38,6 +39,13 @@ describe('getMenuItemsFromRoutes', () => {
         icon: 'ico-offres',
         path: '/decouverte',
         title: 'Les offres',
+      },
+      {
+        component: DiscoveryContainerV2,
+        featureName: 'RECOMMENDATIONS_WITH_MATERIALIZED_VIEW',
+        icon: 'ico-offres',
+        path: '/decouverte-v2',
+        title: 'Les offres v2',
       },
       {
         component: SearchContainer,

--- a/src/components/pages/discovery/Deck/Deck.jsx
+++ b/src/components/pages/discovery/Deck/Deck.jsx
@@ -55,7 +55,7 @@ class Deck extends PureComponent {
       width,
     } = this.props
 
-    const index = currentRecommendation && currentRecommendation.index || 0
+    const index = (currentRecommendation && currentRecommendation.index) || 0
     const offset = (data.x + width * index) / width
 
     if (data.y > height * verticalSlideRatio) {
@@ -70,25 +70,25 @@ class Deck extends PureComponent {
   }
 
   handleGoNext = () => {
-    const { history, match, nextRecommendation } = this.props
+    const { history, match, nextRecommendation, pathChunk } = this.props
     if (!nextRecommendation || isDetailsView(match)) {
       return
     }
 
     const { offerId, mediationId } = nextRecommendation
-    const nextUrl = `/decouverte/${offerId || 'tuto'}/${mediationId || 'vide'}`
+    const nextUrl = `${pathChunk}${offerId || 'tuto'}/${mediationId || 'vide'}`
     history.push(nextUrl)
     this.handleRefreshNext()
   }
 
   handleGoPrevious = () => {
-    const { history, match, previousRecommendation } = this.props
+    const { history, match, previousRecommendation, pathChunk } = this.props
     if (!previousRecommendation || isDetailsView(match)) {
       return
     }
 
     const { offerId, mediationId } = previousRecommendation
-    const previousUrl = `/decouverte/${offerId || 'tuto'}/${mediationId || 'vide'}`
+    const previousUrl = `${pathChunk}${offerId || 'tuto'}/${mediationId || 'vide'}`
     history.push(previousUrl)
   }
 
@@ -193,11 +193,10 @@ class Deck extends PureComponent {
         data-nb-recos={nbRecommendations}
         id="deck"
       >
-        {detailView &&
-        <CloseLink
+        {detailView && <CloseLink
           closeTitle="Fermer"
           closeTo={this.buildCloseToUrl()}
-        />}
+                       />}
 
         {this.renderDraggableCards()}
 
@@ -247,6 +246,7 @@ Deck.propTypes = {
   nextLimit: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]).isRequired,
   nextRecommendation: PropTypes.shape(),
   noDataTimeout: PropTypes.number,
+  pathChunk: PropTypes.string.isRequired,
   previousRecommendation: PropTypes.shape(),
   readTimeout: PropTypes.number,
   recommendations: PropTypes.arrayOf(PropTypes.shape()).isRequired,

--- a/src/components/pages/discovery/Discovery.jsx
+++ b/src/components/pages/discovery/Discovery.jsx
@@ -11,6 +11,14 @@ import isDetailsView from '../../../utils/isDetailsView'
 import isCancelView from '../../../utils/isCancelView'
 import { MINIMUM_DELAY_BEFORE_UPDATING_SEED_3_HOURS } from './utils/utils'
 
+export const getPathChunk = () => {
+  if (window.location.pathname.includes('/decouverte-v2/')) {
+    return '/decouverte-v2/'
+  }
+
+  return '/decouverte/'
+}
+
 class Discovery extends PureComponent {
   constructor(props) {
     super(props)
@@ -121,12 +129,18 @@ class Discovery extends PureComponent {
 
   renderBookingCancellation = () => <BookingCancellationContainer />
 
-  renderDeck = () => <DeckContainer handleRequestPutRecommendations={this.updateRecommendations} />
+  renderDeck = () => (
+    <DeckContainer
+      handleRequestPutRecommendations={this.updateRecommendations}
+      pathChunk={getPathChunk()}
+    />
+  )
 
   render() {
     const { match } = this.props
     const { hasError, isEmpty, isLoading } = this.state
     const cancelView = isCancelView(match)
+    const pathChunk = getPathChunk()
 
     return (
       <Fragment>
@@ -135,13 +149,13 @@ class Discovery extends PureComponent {
             <Fragment>
               <Route
                 key="route-discovery-deck"
-                path="/decouverte/:offerId(tuto|[A-Z0-9]+)/:mediationId(vide|fin|[A-Z0-9]+)/:details(details|transition)?/:booking(reservation)?/:bookingId([A-Z0-9]+)?/:cancellation(annulation)?"
+                path={`${pathChunk}:offerId(tuto|[A-Z0-9]+)/:mediationId(vide|fin|[A-Z0-9]+)/:details(details|transition)?/:booking(reservation)?/:bookingId([A-Z0-9]+)?/:cancellation(annulation)?`}
                 render={this.renderDeck}
                 sensitive
               />
               <Route
                 key="route-discovery-booking"
-                path="/decouverte/:offerId(tuto|[A-Z0-9]+)/:mediationId(vide|fin|[A-Z0-9]+)/:details(details)/:booking(reservation)/:bookingId([A-Z0-9]+)?/:cancellation(annulation)?/:confirmation(confirmation)?"
+                path={`${pathChunk}:offerId(tuto|[A-Z0-9]+)/:mediationId(vide|fin|[A-Z0-9]+)/:details(details)/:booking(reservation)/:bookingId([A-Z0-9]+)?/:cancellation(annulation)?/:confirmation(confirmation)?`}
                 render={cancelView ? this.renderBookingCancellation : this.renderBooking}
                 sensitive
               />

--- a/src/components/pages/discovery/Discovery.jsx
+++ b/src/components/pages/discovery/Discovery.jsx
@@ -44,7 +44,7 @@ class Discovery extends PureComponent {
       recommendations,
       redirectToFirstRecommendationIfNeeded,
       seedLastRequestTimestamp,
-      updatePageAndSeedAndLastRequestTimestamp,
+      updateLastRequestTimestamp,
     } = this.props
     const { location: prevLocation } = prevProps
 
@@ -53,7 +53,7 @@ class Discovery extends PureComponent {
     }
 
     if (Date.now() > seedLastRequestTimestamp + MINIMUM_DELAY_BEFORE_UPDATING_SEED_3_HOURS) {
-      updatePageAndSeedAndLastRequestTimestamp()
+      updateLastRequestTimestamp()
     }
   }
 
@@ -92,10 +92,8 @@ class Discovery extends PureComponent {
     const {
       currentRecommendation,
       loadRecommendations,
-      page,
       readRecommendations,
       recommendations,
-      seed,
       shouldReloadRecommendations,
     } = this.props
 
@@ -109,10 +107,8 @@ class Discovery extends PureComponent {
         this.handleSuccess,
         this.handleFail,
         currentRecommendation,
-        page,
         recommendations,
         readRecommendations,
-        seed,
         shouldReloadRecommendations
       )
     })
@@ -185,18 +181,16 @@ Discovery.propTypes = {
       view: PropTypes.string,
     }),
   }).isRequired,
-  page: PropTypes.number.isRequired,
   readRecommendations: PropTypes.arrayOf(PropTypes.shape()),
   recommendations: PropTypes.arrayOf(PropTypes.shape()),
   redirectHome: PropTypes.func.isRequired,
   redirectToFirstRecommendationIfNeeded: PropTypes.func.isRequired,
   resetReadRecommendations: PropTypes.func.isRequired,
   saveLastRecommendationsRequestTimestamp: PropTypes.func.isRequired,
-  seed: PropTypes.number.isRequired,
   seedLastRequestTimestamp: PropTypes.number.isRequired,
   shouldReloadRecommendations: PropTypes.bool.isRequired,
   tutorials: PropTypes.arrayOf(PropTypes.shape()).isRequired,
-  updatePageAndSeedAndLastRequestTimestamp: PropTypes.func.isRequired,
+  updateLastRequestTimestamp: PropTypes.func.isRequired,
 }
 
 export default Discovery

--- a/src/components/pages/discovery/DiscoveryContainer.js
+++ b/src/components/pages/discovery/DiscoveryContainer.js
@@ -2,11 +2,11 @@ import { connect } from 'react-redux'
 import { compose } from 'redux'
 import { assignData, deleteData, requestData } from 'redux-thunk-data'
 import { saveLastRecommendationsRequestTimestamp } from '../../../reducers/data'
-import { updatePage, updateSeed, updateSeedLastRequestTimestamp } from '../../../reducers/pagination'
+import { updateSeedLastRequestTimestamp } from '../../../reducers/pagination'
 import { selectReadRecommendations } from '../../../selectors/data/readRecommendationsSelectors'
 import { selectRecommendations } from '../../../selectors/data/recommendationsSelectors'
-import { selectPage, selectSeed, selectSeedLastRequestTimestamp } from '../../../selectors/pagination/paginationSelector'
-import getOfferIdAndMediationIdApiPathQueryString, { DEFAULT_VIEW_IDENTIFIERS } from '../../../utils/getOfferIdAndMediationIdApiPathQueryString'
+import { selectSeedLastRequestTimestamp } from '../../../selectors/pagination/paginationSelector'
+import getOfferIdAndMediationIdApiPathQueryString from '../../../utils/getOfferIdAndMediationIdApiPathQueryString'
 import { recommendationNormalizer } from '../../../utils/normalizers'
 import withRequiredLogin from '../../hocs/with-login/withRequiredLogin'
 import Discovery from './Discovery'
@@ -22,8 +22,6 @@ export const mapStateToProps = (state, ownProps) => {
   const tutorials = selectTutorials(state)
   const recommendations = selectRecommendations(state)
   const readRecommendations = selectReadRecommendations(state)
-  const page = selectPage(state)
-  const seed = selectSeed(state)
   const hasNoRecommendations = recommendations && recommendations.length === 0
   const shouldReloadRecommendations =
     checkIfShouldReloadRecommendationsBecauseOfLongTime(state) || hasNoRecommendations
@@ -31,10 +29,8 @@ export const mapStateToProps = (state, ownProps) => {
 
   return {
     currentRecommendation,
-    page,
     readRecommendations,
     recommendations,
-    seed,
     seedLastRequestTimestamp,
     shouldReloadRecommendations,
     tutorials,
@@ -49,10 +45,8 @@ export const mapDispatchToProps = (dispatch, prevProps) => ({
     handleSuccess,
     handleFail,
     currentRecommendation,
-    page,
     recommendations,
     readRecommendations,
-    seed,
     shouldReloadRecommendations
   ) => {
     const { match } = prevProps
@@ -61,18 +55,9 @@ export const mapDispatchToProps = (dispatch, prevProps) => ({
       (recommendations && recommendations.map(reco => reco.id))
     let queryParams = getOfferIdAndMediationIdApiPathQueryString(match, currentRecommendation)
 
-    let newPage = page
-    const currentRecommendationIsNotEmpty = currentRecommendation && Object.keys(currentRecommendation).length > 0
-    if (currentRecommendationIsNotEmpty) {
-      if (!DEFAULT_VIEW_IDENTIFIERS.includes(currentRecommendation.mediationId)) {
-        newPage = page + 1
-      }
-    }
-    let paginationParams = `&page=${newPage}&seed=${seed}`
-
     dispatch(
       requestData({
-        apiPath: `/recommendations?${queryParams}${paginationParams}`,
+        apiPath: `/recommendations?${queryParams}`,
         body: {
           readRecommendations,
           seenRecommendationIds,
@@ -83,7 +68,6 @@ export const mapDispatchToProps = (dispatch, prevProps) => ({
         normalizer: recommendationNormalizer,
       })
     )
-    dispatch(updatePage(newPage))
   },
   redirectHome: () => {
     const { history } = prevProps
@@ -111,10 +95,8 @@ export const mapDispatchToProps = (dispatch, prevProps) => ({
   saveLastRecommendationsRequestTimestamp: () => {
     dispatch(saveLastRecommendationsRequestTimestamp())
   },
-  updatePageAndSeedAndLastRequestTimestamp: () => {
+  updateLastRequestTimestamp: () => {
     dispatch(updateSeedLastRequestTimestamp(Date.now()))
-    dispatch(updateSeed(Math.random()))
-    dispatch(updatePage(1))
   },
 })
 

--- a/src/components/pages/discovery/DiscoveryContainerV2.js
+++ b/src/components/pages/discovery/DiscoveryContainerV2.js
@@ -1,0 +1,112 @@
+import { connect } from 'react-redux'
+import { compose } from 'redux'
+import { assignData, deleteData, requestData } from 'redux-thunk-data'
+import { saveLastRecommendationsRequestTimestamp } from '../../../reducers/data'
+import { updateSeedLastRequestTimestamp } from '../../../reducers/pagination'
+import { selectReadRecommendations } from '../../../selectors/data/readRecommendationsSelectors'
+import { selectRecommendations } from '../../../selectors/data/recommendationsSelectors'
+import { selectSeedLastRequestTimestamp } from '../../../selectors/pagination/paginationSelector'
+import getOfferIdAndMediationIdApiPathQueryString from '../../../utils/getOfferIdAndMediationIdApiPathQueryString'
+import { recommendationNormalizer } from '../../../utils/normalizers'
+import withRequiredLogin from '../../hocs/with-login/withRequiredLogin'
+import Discovery from './Discovery'
+import selectCurrentRecommendation from './selectors/selectCurrentRecommendation'
+import selectTutorials from './selectors/selectTutorials'
+import {
+  checkIfShouldReloadRecommendationsBecauseOfLongTime,
+  isDiscoveryStartupUrl,
+} from './utils/utils'
+
+export const mapStateToProps = (state, ownProps) => {
+  const { match } = ownProps
+  const { params } = match
+  const { mediationId, offerId } = params
+  const currentRecommendation = selectCurrentRecommendation(state, offerId, mediationId)
+  const tutorials = selectTutorials(state)
+  const recommendations = selectRecommendations(state)
+  const readRecommendations = selectReadRecommendations(state)
+  const hasNoRecommendations = recommendations && recommendations.length === 0
+  const shouldReloadRecommendations =
+    checkIfShouldReloadRecommendationsBecauseOfLongTime(state) || hasNoRecommendations
+  const seedLastRequestTimestamp = selectSeedLastRequestTimestamp(state)
+
+  return {
+    currentRecommendation,
+    readRecommendations,
+    recommendations,
+    seedLastRequestTimestamp,
+    shouldReloadRecommendations,
+    tutorials,
+  }
+}
+
+export const mapDispatchToProps = (dispatch, prevProps) => ({
+  deleteTutorials: recommendations => {
+    dispatch(deleteData({ recommendations }))
+  },
+  loadRecommendations: (
+    handleSuccess,
+    handleFail,
+    currentRecommendation,
+    recommendations,
+    readRecommendations,
+    shouldReloadRecommendations
+  ) => {
+    const { match } = prevProps
+    const seenRecommendationIds =
+      (shouldReloadRecommendations && []) ||
+      (recommendations && recommendations.map(reco => reco.id))
+    let queryParams = getOfferIdAndMediationIdApiPathQueryString(match, currentRecommendation)
+
+    dispatch(
+      requestData({
+        apiPath: `/recommendations/v2?${queryParams}`,
+        body: {
+          readRecommendations,
+          seenRecommendationIds,
+        },
+        handleFail: handleFail,
+        handleSuccess: handleSuccess,
+        method: 'PUT',
+        normalizer: recommendationNormalizer,
+      })
+    )
+  },
+  redirectHome: () => {
+    const { history } = prevProps
+    setTimeout(() => history.replace('/connexion'), 2000)
+  },
+  redirectToFirstRecommendationIfNeeded: loadedRecommendations => {
+    const { match, history } = prevProps
+
+    if (!loadedRecommendations) {
+      return
+    }
+
+    const shouldRedirectToFirstRecommendationUrl =
+      loadedRecommendations.length > 0 && isDiscoveryStartupUrl(match)
+    if (!shouldRedirectToFirstRecommendationUrl) {
+      return
+    }
+    const firstOfferId = loadedRecommendations[0].offerId || 'tuto'
+    const firstMediationId = loadedRecommendations[0].mediationId || 'vide'
+    history.replace(`/decouverte-v2/${firstOfferId}/${firstMediationId}`)
+  },
+  resetReadRecommendations: () => {
+    dispatch(assignData({ readRecommendations: [] }))
+  },
+  saveLastRecommendationsRequestTimestamp: () => {
+    dispatch(saveLastRecommendationsRequestTimestamp())
+  },
+  updateLastRequestTimestamp: () => {
+    dispatch(updateSeedLastRequestTimestamp(Date.now()))
+  },
+})
+
+export default compose(
+  withRequiredLogin,
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )
+)(Discovery)

--- a/src/components/pages/discovery/__specs__/Discovery.spec.jsx
+++ b/src/components/pages/discovery/__specs__/Discovery.spec.jsx
@@ -18,7 +18,6 @@ describe('src | components | pages | discovery | Discovery', () => {
       match: {
         params: {},
       },
-      page: 1,
       redirectHome: jest.fn(),
       readRecommendations: [],
       recommendations: [],
@@ -27,11 +26,10 @@ describe('src | components | pages | discovery | Discovery', () => {
       resetRecommendations: jest.fn(),
       resetRecommendationsAndBookings: jest.fn(),
       saveLastRecommendationsRequestTimestamp: jest.fn(),
-      seed: 0.5,
       seedLastRequestTimestamp: 1574236357670,
       shouldReloadRecommendations: false,
       tutorials: [],
-      updatePageAndSeedAndLastRequestTimestamp: jest.fn(),
+      updateLastRequestTimestamp: jest.fn(),
     }
   })
 
@@ -71,10 +69,8 @@ describe('src | components | pages | discovery | Discovery', () => {
         expect.any(Function),
         expect.any(Function),
         props.currentRecommendation,
-        props.page,
         props.recommendations,
         props.readRecommendations,
-        props.seed,
         props.shouldReloadRecommendations
       )
       expect(props.saveLastRecommendationsRequestTimestamp).toHaveBeenCalledWith()
@@ -90,27 +86,33 @@ describe('src | components | pages | discovery | Discovery', () => {
       // then
       expect(props.loadRecommendations).not.toHaveBeenCalledWith()
       expect(props.saveLastRecommendationsRequestTimestamp).not.toHaveBeenCalledWith()
-      expect(props.redirectToFirstRecommendationIfNeeded).toHaveBeenCalledWith(props.recommendations)
+      expect(props.redirectToFirstRecommendationIfNeeded).toHaveBeenCalledWith(
+        props.recommendations
+      )
     })
   })
 
   describe('when unmount', () => {
     it('should delete tutorials for current user', () => {
       // given
-      props.tutorials = [{
-        id: 'hello',
-        productOrTutoIdentifier: 'tuto_0',
-      }]
+      props.tutorials = [
+        {
+          id: 'hello',
+          productOrTutoIdentifier: 'tuto_0',
+        },
+      ]
       const wrapper = shallow(<Discovery {...props} />)
 
       // when
       wrapper.unmount()
 
       // then
-      expect(props.deleteTutorials).toHaveBeenCalledWith([{
-        id: 'hello',
-        productOrTutoIdentifier: 'tuto_0',
-      }])
+      expect(props.deleteTutorials).toHaveBeenCalledWith([
+        {
+          id: 'hello',
+          productOrTutoIdentifier: 'tuto_0',
+        },
+      ])
     })
 
     it('should not delete tutorials for current user', () => {
@@ -132,8 +134,8 @@ describe('src | components | pages | discovery | Discovery', () => {
         // given
         const action = {
           payload: {
-            data: [{ id: 'ABC1' }]
-          }
+            data: [{ id: 'ABC1' }],
+          },
         }
         const wrapper = shallow(<Discovery {...props} />)
 
@@ -148,8 +150,8 @@ describe('src | components | pages | discovery | Discovery', () => {
         // given
         const action = {
           payload: {
-            data: []
-          }
+            data: [],
+          },
         }
         props.recommendations = [{ id: 'ABC1' }]
         const wrapper = shallow(<Discovery {...props} />)
@@ -162,7 +164,7 @@ describe('src | components | pages | discovery | Discovery', () => {
           atWorldsEnd: true,
           hasError: false,
           isEmpty: false,
-          isLoading: false
+          isLoading: false,
         })
       })
 
@@ -170,8 +172,8 @@ describe('src | components | pages | discovery | Discovery', () => {
         // given
         const action = {
           payload: {
-            data: [{ id: 'DEF2' }]
-          }
+            data: [{ id: 'DEF2' }],
+          },
         }
         props.recommendations = [{ id: 'ABC1' }]
         const wrapper = shallow(<Discovery {...props} />)
@@ -184,7 +186,7 @@ describe('src | components | pages | discovery | Discovery', () => {
           atWorldsEnd: false,
           hasError: false,
           isEmpty: false,
-          isLoading: false
+          isLoading: false,
         })
       })
 
@@ -192,8 +194,8 @@ describe('src | components | pages | discovery | Discovery', () => {
         // given
         const action = {
           payload: {
-            data: []
-          }
+            data: [],
+          },
         }
         props.recommendations = []
         const wrapper = shallow(<Discovery {...props} />)
@@ -206,7 +208,7 @@ describe('src | components | pages | discovery | Discovery', () => {
           atWorldsEnd: true,
           hasError: false,
           isEmpty: true,
-          isLoading: false
+          isLoading: false,
         })
       })
     })
@@ -225,45 +227,47 @@ describe('src | components | pages | discovery | Discovery', () => {
           atWorldsEnd: false,
           hasError: true,
           isEmpty: null,
-          isLoading: true
+          isLoading: true,
         })
       })
     })
   })
 
   describe('when update', () => {
-    it('should update seed and seed last request timestamp when date is posterior to limit', () => {
+    it('should update seed last request timestamp when date is posterior to limit', () => {
       // given
       jest
         .spyOn(global.Date, 'now')
-        .mockImplementationOnce(() =>
-          new Date('2019-11-20T13:00:00.000Z').valueOf()
-        )
+        .mockImplementationOnce(() => new Date('2019-11-20T13:00:00.000Z').valueOf())
 
       // when
       const wrapper = shallow(<Discovery {...props} />)
-      props.seed = 1
+      props.location = {
+        pathname: 'nouveauPath',
+        search: '',
+      }
       wrapper.setProps(props)
 
       // then
-      expect(props.updatePageAndSeedAndLastRequestTimestamp).toHaveBeenCalledWith()
+      expect(props.updateLastRequestTimestamp).toHaveBeenCalledWith()
     })
 
-    it('should not update seed and seed last request timestamp when date is anterior to limit', () => {
+    it('should not update seed last request timestamp when date is anterior to limit', () => {
       // given
       jest
         .spyOn(global.Date, 'now')
-        .mockImplementationOnce(() =>
-          new Date('2019-11-20T00:00:00.000Z').valueOf()
-        )
+        .mockImplementationOnce(() => new Date('2019-11-20T00:00:00.000Z').valueOf())
 
       // when
       const wrapper = shallow(<Discovery {...props} />)
-      props.seed = 1
+      props.location = {
+        pathname: 'nouveauPath',
+        search: '',
+      }
       wrapper.setProps(props)
 
       // then
-      expect(props.updatePageAndSeedAndLastRequestTimestamp).not.toHaveBeenCalledWith()
+      expect(props.updateLastRequestTimestamp).not.toHaveBeenCalledWith()
     })
   })
 })

--- a/src/components/pages/discovery/__specs__/DiscoveryContainer.spec.js
+++ b/src/components/pages/discovery/__specs__/DiscoveryContainer.spec.js
@@ -18,8 +18,6 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
   let dispatch
   let replace
   let props
-  const page = 1
-  const seed = 0.5
 
   beforeEach(() => {
     dispatch = jest.fn()
@@ -48,8 +46,6 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
           recommendations: [],
         },
         pagination: {
-          page: 1,
-          seed: 0.5,
           seedLastRequestTimestamp: 11111111112,
         },
       }
@@ -78,10 +74,8 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
           productOrTutoIdentifier: 'tuto_-1',
           thumbUrl: 'http://localhost/splash-finReco@2x.png',
         },
-        page: 1,
         readRecommendations: undefined,
         recommendations: [],
-        seed: 0.5,
         seedLastRequestTimestamp: 11111111112,
         shouldReloadRecommendations: true,
         tutorials: [],
@@ -107,17 +101,15 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
           handleRequestSuccess,
           handleRequestFail,
           currentRecommendation,
-          page,
           recommendations,
           readRecommendations,
-          seed,
           shouldReloadRecommendations
         )
 
         // then
         expect(dispatch.mock.calls[0][0]).toStrictEqual({
           config: {
-            apiPath: `/recommendations?&page=1&seed=0.5`,
+            apiPath: `/recommendations?`,
             body: {
               readRecommendations: null,
               seenRecommendationIds: [],
@@ -127,11 +119,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
             method: 'PUT',
             normalizer: recommendationNormalizer,
           },
-          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS?&PAGE=1&SEED=0.5',
-        })
-        expect(dispatch.mock.calls[1][0]).toStrictEqual({
-          page: 1,
-          type: 'UPDATE_PAGE',
+          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS?',
         })
       })
 
@@ -151,17 +139,15 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
           handleRequestSuccess,
           handleRequestFail,
           currentRecommendation,
-          page,
           recommendations,
           readRecommendations,
-          seed,
           shouldReloadRecommendations
         )
 
         // then
         expect(dispatch.mock.calls[0][0]).toStrictEqual({
           config: {
-            apiPath: `/recommendations?&page=1&seed=0.5`,
+            apiPath: `/recommendations?`,
             body: {
               readRecommendations: null,
               seenRecommendationIds: [],
@@ -171,11 +157,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
             method: 'PUT',
             normalizer: recommendationNormalizer,
           },
-          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS?&PAGE=1&SEED=0.5',
-        })
-        expect(dispatch.mock.calls[1][0]).toStrictEqual({
-          page: 1,
-          type: 'UPDATE_PAGE',
+          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS?',
         })
       })
 
@@ -195,17 +177,15 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
           handleRequestSuccess,
           handleRequestFail,
           currentRecommendation,
-          page,
           recommendations,
           readRecommendations,
-          seed,
           shouldReloadRecommendations
         )
 
         // then
         expect(dispatch.mock.calls[0][0]).toStrictEqual({
           config: {
-            apiPath: `/recommendations?&page=1&seed=0.5`,
+            apiPath: `/recommendations?`,
             body: {
               readRecommendations: null,
               seenRecommendationIds: [],
@@ -215,11 +195,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
             method: 'PUT',
             normalizer: recommendationNormalizer,
           },
-          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS?&PAGE=1&SEED=0.5',
-        })
-        expect(dispatch.mock.calls[1][0]).toStrictEqual({
-          page: 1,
-          type: 'UPDATE_PAGE',
+          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS?',
         })
       })
 
@@ -239,17 +215,15 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
           handleRequestSuccess,
           handleRequestFail,
           currentRecommendation,
-          page,
           recommendations,
           readRecommendations,
-          seed,
           shouldReloadRecommendations
         )
 
         // then
         expect(dispatch.mock.calls[0][0]).toStrictEqual({
           config: {
-            apiPath: `/recommendations?&page=1&seed=0.5`,
+            apiPath: `/recommendations?`,
             body: {
               readRecommendations: null,
               seenRecommendationIds: [],
@@ -259,11 +233,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
             method: 'PUT',
             normalizer: recommendationNormalizer,
           },
-          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS?&PAGE=1&SEED=0.5',
-        })
-        expect(dispatch.mock.calls[1][0]).toStrictEqual({
-          page: 1,
-          type: 'UPDATE_PAGE',
+          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS?',
         })
       })
 
@@ -287,17 +257,15 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
           handleRequestSuccess,
           handleRequestFail,
           currentRecommendation,
-          page,
           recommendations,
           readRecommendations,
-          seed,
           shouldReloadRecommendations
         )
 
         // then
         expect(dispatch.mock.calls[0][0]).toStrictEqual({
           config: {
-            apiPath: `/recommendations?&page=2&seed=0.5`,
+            apiPath: `/recommendations?`,
             body: {
               readRecommendations: null,
               seenRecommendationIds: ['AE3'],
@@ -307,11 +275,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
             method: 'PUT',
             normalizer: recommendationNormalizer,
           },
-          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS?&PAGE=2&SEED=0.5',
-        })
-        expect(dispatch.mock.calls[1][0]).toStrictEqual({
-          page: 2,
-          type: 'UPDATE_PAGE',
+          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS?',
         })
       })
     })
@@ -469,23 +433,15 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
       })
     })
 
-    describe('when mapping updatePageAndSeedAndLastRequestTimestamp', () => {
+    describe('when mapping updateLastRequestTimestamp', () => {
       it('should save update last seed request timestamp', () => {
         // when
-        mapDispatchToProps(dispatch, props).updatePageAndSeedAndLastRequestTimestamp()
+        mapDispatchToProps(dispatch, props).updateLastRequestTimestamp()
 
         // then
         expect(dispatch.mock.calls[0][0]).toStrictEqual({
           seedLastRequestTimestamp: expect.any(Number),
           type: 'UPDATE_SEED_LAST_REQUEST_TIMESTAMP',
-        })
-        expect(dispatch.mock.calls[1][0]).toStrictEqual({
-          seed: expect.any(Number),
-          type: 'UPDATE_SEED',
-        })
-        expect(dispatch.mock.calls[2][0]).toStrictEqual({
-          page: 1,
-          type: 'UPDATE_PAGE',
         })
       })
     })

--- a/src/components/pages/discovery/__specs__/DiscoveryContainerV2.spec.js
+++ b/src/components/pages/discovery/__specs__/DiscoveryContainerV2.spec.js
@@ -1,0 +1,404 @@
+import { mapDispatchToProps } from '../DiscoveryContainerV2'
+import { recommendationNormalizer } from '../../../../utils/normalizers'
+
+jest.mock('redux-thunk-data', () => {
+  const { assignData, createDataReducer, deleteData, requestData } = jest.requireActual(
+    'fetch-normalize-data'
+  )
+  return {
+    assignData,
+    createDataReducer,
+    deleteData,
+    requestData,
+  }
+})
+jest.useFakeTimers()
+
+describe('src | components | pages | discovery | DiscoveryContainer', () => {
+  let dispatch
+  let replace
+  let props
+
+  beforeEach(() => {
+    dispatch = jest.fn()
+    replace = jest.fn()
+    props = {
+      history: {
+        replace,
+      },
+      location: {
+        search: '',
+      },
+      match: {
+        params: {},
+      },
+      query: {
+        parse: () => ({}),
+      },
+    }
+  })
+
+  describe('mapDispatchToProps()', () => {
+    describe('when mapping loadRecommendations', () => {
+      it('should load the recommendations with page equals 1 when no current recommendation', () => {
+        // given
+        const handleRequestSuccess = jest.fn()
+        const handleRequestFail = jest.fn()
+        const currentRecommendation = {}
+        const recommendations = []
+        const readRecommendations = null
+        const shouldReloadRecommendations = false
+        const functions = mapDispatchToProps(dispatch, props)
+        const { loadRecommendations } = functions
+
+        // when
+        loadRecommendations(
+          handleRequestSuccess,
+          handleRequestFail,
+          currentRecommendation,
+          recommendations,
+          readRecommendations,
+          shouldReloadRecommendations
+        )
+
+        // then
+        expect(dispatch.mock.calls[0][0]).toStrictEqual({
+          config: {
+            apiPath: `/recommendations/v2?`,
+            body: {
+              readRecommendations: null,
+              seenRecommendationIds: [],
+            },
+            handleFail: handleRequestFail,
+            handleSuccess: handleRequestSuccess,
+            method: 'PUT',
+            normalizer: recommendationNormalizer,
+          },
+          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS/V2?',
+        })
+      })
+
+      it('should load the recommendations with page equals 1 when current recommendation is a tuto', () => {
+        // given
+        const handleRequestSuccess = jest.fn()
+        const handleRequestFail = jest.fn()
+        const currentRecommendation = { mediationId: 'tuto' }
+        const recommendations = []
+        const readRecommendations = null
+        const shouldReloadRecommendations = false
+        const functions = mapDispatchToProps(dispatch, props)
+        const { loadRecommendations } = functions
+
+        // when
+        loadRecommendations(
+          handleRequestSuccess,
+          handleRequestFail,
+          currentRecommendation,
+          recommendations,
+          readRecommendations,
+          shouldReloadRecommendations
+        )
+
+        // then
+        expect(dispatch.mock.calls[0][0]).toStrictEqual({
+          config: {
+            apiPath: `/recommendations/v2?`,
+            body: {
+              readRecommendations: null,
+              seenRecommendationIds: [],
+            },
+            handleFail: handleRequestFail,
+            handleSuccess: handleRequestSuccess,
+            method: 'PUT',
+            normalizer: recommendationNormalizer,
+          },
+          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS/V2?',
+        })
+      })
+
+      it('should load the recommendations with page equals 1 when current recommendation is the final card', () => {
+        // given
+        const handleRequestSuccess = jest.fn()
+        const handleRequestFail = jest.fn()
+        const currentRecommendation = { mediationId: 'fin' }
+        const recommendations = []
+        const readRecommendations = null
+        const shouldReloadRecommendations = false
+        const functions = mapDispatchToProps(dispatch, props)
+        const { loadRecommendations } = functions
+
+        // when
+        loadRecommendations(
+          handleRequestSuccess,
+          handleRequestFail,
+          currentRecommendation,
+          recommendations,
+          readRecommendations,
+          shouldReloadRecommendations
+        )
+
+        // then
+        expect(dispatch.mock.calls[0][0]).toStrictEqual({
+          config: {
+            apiPath: `/recommendations/v2?`,
+            body: {
+              readRecommendations: null,
+              seenRecommendationIds: [],
+            },
+            handleFail: handleRequestFail,
+            handleSuccess: handleRequestSuccess,
+            method: 'PUT',
+            normalizer: recommendationNormalizer,
+          },
+          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS/V2?',
+        })
+      })
+
+      it('should load the recommendations with page equals 1 when current recommendation has an empty mediation', () => {
+        // given
+        const handleRequestSuccess = jest.fn()
+        const handleRequestFail = jest.fn()
+        const currentRecommendation = { mediationId: 'vide' }
+        const recommendations = []
+        const readRecommendations = null
+        const shouldReloadRecommendations = false
+        const functions = mapDispatchToProps(dispatch, props)
+        const { loadRecommendations } = functions
+
+        // when
+        loadRecommendations(
+          handleRequestSuccess,
+          handleRequestFail,
+          currentRecommendation,
+          recommendations,
+          readRecommendations,
+          shouldReloadRecommendations
+        )
+
+        // then
+        expect(dispatch.mock.calls[0][0]).toStrictEqual({
+          config: {
+            apiPath: `/recommendations/v2?`,
+            body: {
+              readRecommendations: null,
+              seenRecommendationIds: [],
+            },
+            handleFail: handleRequestFail,
+            handleSuccess: handleRequestSuccess,
+            method: 'PUT',
+            normalizer: recommendationNormalizer,
+          },
+          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS/V2?',
+        })
+      })
+
+      it('should load the recommendations with page equals 2 when current recommendation is a valid one attached to an offer', () => {
+        // given
+        const handleRequestSuccess = jest.fn()
+        const handleRequestFail = jest.fn()
+        const currentRecommendation = {
+          id: 'ABC3',
+          index: 1,
+          offerId: 'ABC2',
+        }
+        const recommendations = [{ id: 'AE3', index: 3 }]
+        const readRecommendations = null
+        const shouldReloadRecommendations = false
+        const functions = mapDispatchToProps(dispatch, props)
+        const { loadRecommendations } = functions
+
+        // when
+        loadRecommendations(
+          handleRequestSuccess,
+          handleRequestFail,
+          currentRecommendation,
+          recommendations,
+          readRecommendations,
+          shouldReloadRecommendations
+        )
+
+        // then
+        expect(dispatch.mock.calls[0][0]).toStrictEqual({
+          config: {
+            apiPath: `/recommendations/v2?`,
+            body: {
+              readRecommendations: null,
+              seenRecommendationIds: ['AE3'],
+            },
+            handleFail: handleRequestFail,
+            handleSuccess: handleRequestSuccess,
+            method: 'PUT',
+            normalizer: recommendationNormalizer,
+          },
+          type: 'REQUEST_DATA_PUT_/RECOMMENDATIONS/V2?',
+        })
+      })
+    })
+
+    describe('when mapping redirectHome', () => {
+      it('should call setTimout 2000 times', () => {
+        // when
+        mapDispatchToProps(dispatch, props).redirectHome()
+
+        // then
+        expect(setTimeout).toHaveBeenCalledTimes(1)
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 2000)
+      })
+
+      it('should replace path by /connexion', () => {
+        // given
+        jest.useFakeTimers()
+
+        // when
+        mapDispatchToProps(dispatch, props).redirectHome()
+        jest.runAllTimers()
+
+        // then
+        expect(replace).toHaveBeenCalledTimes(1)
+        expect(replace).toHaveBeenLastCalledWith('/connexion')
+      })
+    })
+
+    describe('when mapping redirectToFirstRecommendationIfNeeded', () => {
+      describe('when there are no recommendations', () => {
+        it('should return undefined', () => {
+          // given
+          const loadedRecommendations = []
+
+          // when
+          const redirect = mapDispatchToProps(
+            dispatch,
+            props
+          ).redirectToFirstRecommendationIfNeeded(loadedRecommendations)
+
+          // then
+          expect(redirect).toBeUndefined()
+        })
+      })
+
+      describe('when not on discovery pathname', () => {
+        it('should return undefined', () => {
+          // given
+          const loadedRecommendations = [{ id: 'firstRecommendation' }]
+          props.location.pathname = ''
+
+          // when
+          const redirect = mapDispatchToProps(
+            dispatch,
+            props
+          ).redirectToFirstRecommendationIfNeeded(loadedRecommendations)
+
+          // then
+          expect(redirect).toBeUndefined()
+        })
+      })
+
+      describe('when visiting for the first time', () => {
+        it('should redirect to tuto recommendation with a specified mediation', () => {
+          // given
+          const dispatch = jest.fn()
+          const loadedRecommendations = [{ id: 'QA3D', offerId: null, mediationId: 'A9' }]
+          const ownProps = {
+            history: {
+              replace: jest.fn(),
+            },
+            match: {
+              url: '/decouverte',
+              params: {},
+            },
+          }
+
+          // when
+          mapDispatchToProps(dispatch, ownProps).redirectToFirstRecommendationIfNeeded(
+            loadedRecommendations
+          )
+
+          // then
+          expect(ownProps.history.replace).toHaveBeenCalledWith('/decouverte-v2/tuto/A9')
+        })
+
+        it('should redirect to tuto recommendation without mediation', () => {
+          // given
+          const dispatch = jest.fn()
+          const loadedRecommendations = [{ id: 'QA3D', offerId: null, mediationId: null }]
+          const ownProps = {
+            history: {
+              replace: jest.fn(),
+            },
+            match: {
+              url: '/decouverte',
+              params: {},
+            },
+          }
+
+          // when
+          mapDispatchToProps(dispatch, ownProps).redirectToFirstRecommendationIfNeeded(
+            loadedRecommendations
+          )
+
+          // then
+          expect(ownProps.history.replace).toHaveBeenCalledWith('/decouverte-v2/tuto/vide')
+        })
+
+        it('should delete tutos from store when leaving discovery', () => {
+          // given
+          const tutos = {
+            id: 'ABCD',
+          }
+
+          // when
+          mapDispatchToProps(dispatch, null).deleteTutorials(tutos)
+
+          // then
+          expect(dispatch).toHaveBeenCalledWith({
+            config: {},
+            patch: {
+              recommendations: {
+                id: 'ABCD',
+              },
+            },
+            type: 'DELETE_DATA',
+          })
+        })
+      })
+    })
+
+    describe('when mapping resetReadRecommendations', () => {
+      it('should reset recommendations with the right configuration', () => {
+        // when
+        mapDispatchToProps(dispatch, props).resetReadRecommendations()
+
+        // then
+        expect(dispatch).toHaveBeenCalledWith({
+          patch: { readRecommendations: [] },
+          type: 'ASSIGN_DATA',
+        })
+      })
+    })
+
+    describe('when mapping saveLastRecommendationsRequestTimestamp', () => {
+      it('should save recommendations loaded timestamp with the right configuration', () => {
+        // when
+        mapDispatchToProps(dispatch, props).saveLastRecommendationsRequestTimestamp()
+
+        // then
+        expect(dispatch).toHaveBeenCalledWith({
+          type: 'SAVE_RECOMMENDATIONS_REQUEST_TIMESTAMP',
+        })
+      })
+    })
+
+    describe('when mapping updateLastRequestTimestamp', () => {
+      it('should save update last seed request timestamp', () => {
+        // when
+        mapDispatchToProps(dispatch, props).updateLastRequestTimestamp()
+
+        // then
+        expect(dispatch.mock.calls[0][0]).toStrictEqual({
+          seedLastRequestTimestamp: expect.any(Number),
+          type: 'UPDATE_SEED_LAST_REQUEST_TIMESTAMP',
+        })
+      })
+    })
+  })
+})

--- a/src/components/pages/discovery/__specs__/__snapshots__/Discovery.spec.jsx.snap
+++ b/src/components/pages/discovery/__specs__/__snapshots__/Discovery.spec.jsx.snap
@@ -18,7 +18,6 @@ ShallowWrapper {
         "params": Object {},
       }
     }
-    page={1}
     readRecommendations={Array []}
     recommendations={Array []}
     redirectHome={[MockFunction]}
@@ -41,11 +40,10 @@ ShallowWrapper {
     resetRecommendations={[MockFunction]}
     resetRecommendationsAndBookings={[MockFunction]}
     saveLastRecommendationsRequestTimestamp={[MockFunction]}
-    seed={0.5}
     seedLastRequestTimestamp={1574236357670}
     shouldReloadRecommendations={false}
     tutorials={Array []}
-    updatePageAndSeedAndLastRequestTimestamp={[MockFunction]}
+    updateLastRequestTimestamp={[MockFunction]}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],

--- a/src/components/pages/discovery/selectors/__specs__/selectNextRecommendation.spec.js
+++ b/src/components/pages/discovery/selectors/__specs__/selectNextRecommendation.spec.js
@@ -25,7 +25,6 @@ describe('src | components | pages | discovery | selectors | selectNextRecommend
     // then
     const expected = {
       index: 1,
-      path: `/decouverte/${nextRecommendation.offerId}/`,
       ...nextRecommendation,
     }
     expect(result).toStrictEqual(expected)

--- a/src/components/pages/discovery/selectors/__specs__/selectPreviousRecommendation.spec.js
+++ b/src/components/pages/discovery/selectors/__specs__/selectPreviousRecommendation.spec.js
@@ -25,8 +25,7 @@ describe('components | selectPreviousRecommendation', () => {
     expect(result).toStrictEqual({
       index: 0,
       offerId: 'BF',
-      path: `/decouverte/${previousRecommendation.offerId}/`,
-      productOrTutoIdentifier: 'bar'
+      productOrTutoIdentifier: 'bar',
     })
   })
 

--- a/src/components/pages/discovery/selectors/selectNextRecommendation.js
+++ b/src/components/pages/discovery/selectors/selectNextRecommendation.js
@@ -11,13 +11,14 @@ const selectNextRecommendation = createCachedSelector(
       return null
     }
 
-    const nextRecommendation = recommendations.find(recommendation => recommendation.index === currentRecommendation.index + 1)
+    const nextRecommendation = recommendations.find(
+      recommendation => recommendation.index === currentRecommendation.index + 1
+    )
     if (!nextRecommendation) {
       return null
     }
-    const { mediationId, offerId } = nextRecommendation
-    const path = `/decouverte/${offerId}/${mediationId || ''}`
-    return Object.assign({ path }, nextRecommendation)
+
+    return nextRecommendation
   }
 )(mapArgsToCacheKey)
 

--- a/src/components/pages/discovery/selectors/selectPreviousRecommendation.js
+++ b/src/components/pages/discovery/selectors/selectPreviousRecommendation.js
@@ -13,20 +13,15 @@ const selectPreviousRecommendation = createCachedSelector(
       const currentRecommendationIndex = recommendations.findIndex(
         recommendation => recommendation.id === currentRecommendation.id
       )
-      previousRecommendation = currentRecommendation && recommendations[currentRecommendationIndex - 1]
+      previousRecommendation =
+        currentRecommendation && recommendations[currentRecommendationIndex - 1]
     }
 
     if (!previousRecommendation) {
       return null
     }
 
-    const { mediationId, offerId } = previousRecommendation
-    const path = `/decouverte/${offerId}/${mediationId || ''}`
-
-    return {
-      path,
-      ...previousRecommendation
-    }
+    return previousRecommendation
   }
 )(mapArgsToCacheKey)
 

--- a/src/components/pages/search/SearchContainer.js
+++ b/src/components/pages/search/SearchContainer.js
@@ -10,7 +10,6 @@ import {
 } from '../../../selectors/data/typesSelectors'
 import { selectSearchedRecommendations } from '../../../selectors/data/searchedRecommendationsSelectors'
 import { recommendationNormalizer } from '../../../utils/normalizers'
-import { updatePage } from '../../../reducers/pagination'
 
 export const mapStateToProps = state => {
   const searchedRecommendations = selectSearchedRecommendations(state)
@@ -37,7 +36,6 @@ export const mapDispatchToProps = dispatch => ({
         stateKey: 'searchedRecommendations',
       })
     )
-    dispatch(updatePage(1))
   },
 
   getTypes: () => {

--- a/src/components/pages/search/__specs__/SearchContainer.spec.jsx
+++ b/src/components/pages/search/__specs__/SearchContainer.spec.jsx
@@ -45,9 +45,8 @@ describe('src | components | pages | SearchContainer', () => {
         mapDispatchToProps(dispatch, props).getSearchedRecommendations(apiPath)
 
         // then
-        const firstDispatchedAction = dispatch.mock.calls[0][0]
-        const secondDispatchedAction = dispatch.mock.calls[1][0]
-        expect(firstDispatchedAction).toStrictEqual({
+        const dispatchedAction = dispatch.mock.calls[0][0]
+        expect(dispatchedAction).toStrictEqual({
           config: {
             apiPath: '/recommendations?categories=Applaudir',
             handleSuccess: undefined,
@@ -71,10 +70,6 @@ describe('src | components | pages | SearchContainer', () => {
             stateKey: 'searchedRecommendations',
           },
           type: 'REQUEST_DATA_GET_SEARCHEDRECOMMENDATIONS',
-        })
-        expect(secondDispatchedAction).toStrictEqual({
-          page: 1,
-          type: 'UPDATE_PAGE',
         })
       })
     })

--- a/src/components/router/routes.jsx
+++ b/src/components/router/routes.jsx
@@ -5,6 +5,7 @@ import ActivationContainer from '../pages/activation/ActivationContainer'
 import BetaPageContainer from '../pages/beta-page/BetaPageContainer'
 import MyBookingsContainer from '../pages/my-bookings/MyBookingsContainer'
 import DiscoveryContainer from '../pages/discovery/DiscoveryContainer'
+import DiscoveryContainerV2 from '../pages/discovery/DiscoveryContainerV2'
 import MyFavoritesContainer from '../pages/my-favorites/MyFavoritesContainer'
 import ForgotPassword from '../pages/forgot-password/ForgotPassword'
 import OfferContainer from '../pages/offer/OfferContainer'
@@ -75,6 +76,14 @@ const routes = [
     path:
       '/decouverte/:offerId(tuto|[A-Z0-9]+)?/:mediationId(vide|fin|[A-Z0-9]+)?/:details(details|transition)?/:booking(reservation)?/:bookingId([A-Z0-9]+)?/:cancellation(annulation)?/:confirmation(confirmation)?',
     title: 'Les offres',
+  },
+  {
+    component: DiscoveryContainerV2,
+    featureName: 'RECOMMENDATIONS_WITH_MATERIALIZED_VIEW',
+    icon: 'ico-offres',
+    path:
+      '/decouverte-v2/:offerId(tuto|[A-Z0-9]+)?/:mediationId(vide|fin|[A-Z0-9]+)?/:details(details|transition)?/:booking(reservation)?/:bookingId([A-Z0-9]+)?/:cancellation(annulation)?/:confirmation(confirmation)?',
+    title: 'Les offres v2',
   },
   {
     component: SearchContainer,

--- a/src/reducers/__specs__/pagination.spec.js
+++ b/src/reducers/__specs__/pagination.spec.js
@@ -1,35 +1,7 @@
-import paginationReducer, { updatePage, updateSeed, updateSeedLastRequestTimestamp } from '../pagination'
+import paginationReducer, { updateSeedLastRequestTimestamp } from '../pagination'
 
 describe('src | reducers | pagination', () => {
   describe('actions', () => {
-    it('should return an action of type UPDATE_PAGE', () => {
-      // given
-      const page = 1
-
-      // when
-      const result = updatePage(page)
-
-      // then
-      expect(result).toStrictEqual({
-        page: 1,
-        type: 'UPDATE_PAGE'
-      })
-    })
-
-    it('should return an action of type UPDATE_SEED', () => {
-      // given
-      const seed = 0.5
-
-      // when
-      const result = updateSeed(seed)
-
-      // then
-      expect(result).toStrictEqual({
-        seed: 0.5,
-        type: 'UPDATE_SEED'
-      })
-    })
-
     it('should return an action of type UPDATE_SEED_LAST_REQUEST_TIMESTAMP', () => {
       // given
       const timestamp = 1574186119058
@@ -40,7 +12,7 @@ describe('src | reducers | pagination', () => {
       // then
       expect(result).toStrictEqual({
         seedLastRequestTimestamp: 1574186119058,
-        type: 'UPDATE_SEED_LAST_REQUEST_TIMESTAMP'
+        type: 'UPDATE_SEED_LAST_REQUEST_TIMESTAMP',
       })
     })
   })
@@ -52,44 +24,7 @@ describe('src | reducers | pagination', () => {
 
       // then
       expect(nextState).toStrictEqual({
-        page: 1,
-        seed: expect.any(Number),
-        seedLastRequestTimestamp: expect.any(Number)
-      })
-    })
-
-    describe('when a UPDATE_PAGE action is received', () => {
-      it('should update page to 2', () => {
-        // when
-        const nextState = paginationReducer({ page: 1, seed: 0.5, seedLastRequestTimestamp: 1574186119058 }, {
-          page: 2,
-          type: 'UPDATE_PAGE'
-        })
-
-        // then
-        expect(nextState).toStrictEqual({
-          page: 2,
-          seed: 0.5,
-          seedLastRequestTimestamp: 1574186119058
-        })
-      })
-    })
-
-    describe('when a UPDATE_SEED action is received', () => {
-      it('should update seed to 0.5', () => {
-        // when
-        const nextState = paginationReducer({
-          page: 1,
-          seed: 0.1,
-          seedLastRequestTimestamp: 1574186119058
-        }, { seed: 0.5, type: 'UPDATE_SEED' })
-
-        // then
-        expect(nextState).toStrictEqual({
-          page: 1,
-          seed: 0.5,
-          seedLastRequestTimestamp: 1574186119058
-        })
+        seedLastRequestTimestamp: expect.any(Number),
       })
     })
 
@@ -97,15 +32,13 @@ describe('src | reducers | pagination', () => {
       it('should update seed last request timestamp', () => {
         // when
         const nextState = paginationReducer(
-          { page: 1, seed: 0.1, seedLastRequestTimestamp: 1574186119058 },
+          { seedLastRequestTimestamp: 1574186119058 },
           { seedLastRequestTimestamp: 167283098390, type: 'UPDATE_SEED_LAST_REQUEST_TIMESTAMP' }
         )
 
         // then
         expect(nextState).toStrictEqual({
-          page: 1,
-          seed: 0.1,
-          seedLastRequestTimestamp: 167283098390
+          seedLastRequestTimestamp: 167283098390,
         })
       })
     })

--- a/src/reducers/pagination.js
+++ b/src/reducers/pagination.js
@@ -1,19 +1,11 @@
-const UPDATE_PAGE = 'UPDATE_PAGE'
-const UPDATE_SEED = 'UPDATE_SEED'
 const UPDATE_SEED_LAST_REQUEST_TIMESTAMP = 'UPDATE_SEED_LAST_REQUEST_TIMESTAMP'
 
 const initialState = {
-  page: 1,
-  seed: Math.random(),
-  seedLastRequestTimestamp: Date.now()
+  seedLastRequestTimestamp: Date.now(),
 }
 
 const paginationReducer = (state = initialState, action = {}) => {
-  switch(action.type){
-    case UPDATE_PAGE:
-      return Object.assign({}, state, { page: action.page })
-    case UPDATE_SEED:
-      return Object.assign({}, state, { seed: action.seed })
+  switch (action.type) {
     case UPDATE_SEED_LAST_REQUEST_TIMESTAMP:
       return Object.assign({}, state, { seedLastRequestTimestamp: action.seedLastRequestTimestamp })
     default:
@@ -21,17 +13,7 @@ const paginationReducer = (state = initialState, action = {}) => {
   }
 }
 
-export const updatePage = (page) => ({
-  page,
-  type: UPDATE_PAGE,
-})
-
-export const updateSeed = (seed) => ({
-  seed,
-  type: UPDATE_SEED,
-})
-
-export const updateSeedLastRequestTimestamp = (seedLastRequestTimestamp) => ({
+export const updateSeedLastRequestTimestamp = seedLastRequestTimestamp => ({
   seedLastRequestTimestamp,
   type: UPDATE_SEED_LAST_REQUEST_TIMESTAMP,
 })

--- a/src/selectors/pagination/paginationSelector.js
+++ b/src/selectors/pagination/paginationSelector.js
@@ -1,5 +1,1 @@
-export const selectSeed = state => state.pagination.seed
-
-export const selectPage = state => state.pagination.page
-
 export const selectSeedLastRequestTimestamp = state => state.pagination.seedLastRequestTimestamp


### PR DESCRIPTION
- on a enlevé tout ce qui est lié à l'ancienne implémentation : seed et page;
- on a ajouté la nouvelle route pour voir le carrousel avec la vue matérialisée en ajoutant juste un `DiscoveryContainerV2` et en mettant en variable le chemin `decouverte`.