### PR TITLE
(PC-3088): removed webkit default input search style and added focus …

### DIFF
--- a/src/components/pages/search-algolia/Result/SearchResults.jsx
+++ b/src/components/pages/search-algolia/Result/SearchResults.jsx
@@ -86,6 +86,7 @@ class SearchResults extends PureComponent {
         }
       )
     }
+    this.inputRef.current.blur()
   }
 
   fetchNextOffers = currentPage => {

--- a/src/components/pages/search-algolia/Result/__specs__/SearchResults.spec.jsx
+++ b/src/components/pages/search-algolia/Result/__specs__/SearchResults.spec.jsx
@@ -1009,6 +1009,37 @@ describe('components | SearchResults', () => {
       })
     })
 
+    it('should remove focus from input when the form is submited', () => {
+      // given
+      const wrapper = shallow(<SearchResults {...props} />)
+      const instance = wrapper.instance()
+      stubRef(wrapper)
+      const form = wrapper.find('form')
+      fetchAlgolia.mockReturnValue({
+        hits: [],
+        page: 0,
+        nbHits: 0,
+        nbPages: 0,
+        hitsPerPage: 2,
+        processingTimeMS: 1,
+        query: '',
+        params: 'hitsPerPage=2',
+      })
+
+      // when
+      form.simulate('submit', {
+        target: {
+          keywords: {
+            value: '',
+          },
+        },
+        preventDefault: jest.fn(),
+      })
+
+      // then
+      expect(instance.inputRef.current.blur).toHaveBeenCalledWith()
+    })
+
     describe('reset cross', () => {
       it('should not display reset cross when nothing is typed in text input', () => {
         // when

--- a/src/components/pages/search-algolia/Result/__specs__/SearchResults.spec.jsx
+++ b/src/components/pages/search-algolia/Result/__specs__/SearchResults.spec.jsx
@@ -25,6 +25,15 @@ jest.mock('react-toastify', () => ({
   },
 }))
 
+const stubRef = wrapper => {
+  const instance = wrapper.instance()
+  instance['inputRef'] = {
+    current: {
+      blur: jest.fn()
+    }
+  }
+}
+
 describe('components | SearchResults', () => {
   let props
   let change
@@ -511,8 +520,8 @@ describe('components | SearchResults', () => {
     it('should trigger search request when keywords have been provided', () => {
       // given
       const wrapper = shallow(<SearchResults {...props} />)
+      stubRef(wrapper)
       const form = wrapper.find('form')
-
       // when
       form.simulate('submit', {
         target: {
@@ -541,6 +550,7 @@ describe('components | SearchResults', () => {
     it('should trigger search request when keywords contains only spaces', () => {
       // given
       const wrapper = shallow(<SearchResults {...props} />)
+      stubRef(wrapper)
       wrapper.setState({ searchedKeywords: 'different previous search' })
       const form = wrapper.find('form')
 
@@ -572,6 +582,7 @@ describe('components | SearchResults', () => {
     it('should trigger search request when no keywords', () => {
       // given
       const wrapper = shallow(<SearchResults {...props} />)
+      stubRef(wrapper)
       wrapper.setState({ searchedKeywords: 'different previous search' })
       const form = wrapper.find('form')
 
@@ -603,6 +614,7 @@ describe('components | SearchResults', () => {
     it('should display search keywords and number of results when 0 result', async () => {
       // given
       const wrapper = shallow(<SearchResults {...props} />)
+      stubRef(wrapper)
       const form = wrapper.find('form')
       fetchAlgolia.mockReturnValue(
         new Promise(resolve => {
@@ -639,6 +651,7 @@ describe('components | SearchResults', () => {
     it('should display search keywords and number of results when 2 results', async () => {
       // given
       const wrapper = shallow(<SearchResults {...props} />)
+      stubRef(wrapper)
       const form = wrapper.find('form')
       fetchAlgolia.mockReturnValue(
         new Promise(resolve => {
@@ -675,6 +688,7 @@ describe('components | SearchResults', () => {
     it('should only display number of results when no search keywords', async () => {
       // given
       const wrapper = shallow(<SearchResults {...props} />)
+      stubRef(wrapper)
       wrapper.setState({ searchedKeywords: 'different previous search' })
       const form = wrapper.find('form')
       fetchAlgolia.mockReturnValueOnce(
@@ -710,6 +724,7 @@ describe('components | SearchResults', () => {
     it('should not display results when no results', () => {
       // given
       const wrapper = shallow(<SearchResults {...props} />)
+      stubRef(wrapper)
       const form = wrapper.find('form')
       fetchAlgolia.mockReturnValue({
         hits: [],
@@ -755,6 +770,7 @@ describe('components | SearchResults', () => {
         })
       )
       const wrapper = shallow(<SearchResults {...props} />)
+      stubRef(wrapper)
       const form = wrapper.find('form')
 
       // when
@@ -794,6 +810,7 @@ describe('components | SearchResults', () => {
         })
       )
       const wrapper = shallow(<SearchResults {...props} />)
+      stubRef(wrapper)
       const form = wrapper.find('form')
 
       // when
@@ -875,6 +892,7 @@ describe('components | SearchResults', () => {
         })
       )
       const wrapper = shallow(<SearchResults {...props} />)
+      stubRef(wrapper)
       const form = wrapper.find('form')
 
       // when
@@ -931,6 +949,7 @@ describe('components | SearchResults', () => {
         })
       )
       const wrapper = shallow(<SearchResults {...props} />)
+      stubRef(wrapper)
       const form = wrapper.find('form')
 
       // when
@@ -958,6 +977,7 @@ describe('components | SearchResults', () => {
         categories: 'VISITE',
       })
       const wrapper = shallow(<SearchResults {...props} />)
+      stubRef(wrapper)
       const form = wrapper.find('form')
       fetchAlgolia.mockReturnValue(
         new Promise(resolve => {

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -7,11 +7,12 @@ input {
     opacity: 1;
     color: inherit;
   }
+
+  &[type="search"]::-webkit-search-decoration,
+  &[type="search"]::-webkit-search-cancel-button,
+  &[type="search"]::-webkit-search-results-button,
+  &[type="search"]::-webkit-search-results-decoration {
+    -webkit-appearance:none;
+  }
 }
 
-input[type="search"]::-webkit-search-decoration,
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-results-button,
-input[type="search"]::-webkit-search-results-decoration {
-  -webkit-appearance:none;
-}

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -8,3 +8,10 @@ input {
     color: inherit;
   }
 }
+
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+  -webkit-appearance:none;
+}


### PR DESCRIPTION
- ajout du reset du style par defaut des inputs de type search sur webkit ( pour enlever la croix de reset du champ)
- ajout d'un retrait de focus dans la méthode de submit du formulaire de la page de résultat pour le clavier se repli sur mobile .