### PR TITLE
(pC-3167) transform recoId to offerId on Discovery

### DIFF
--- a/src/components/pages/discovery-v2/DiscoveryContainer.js
+++ b/src/components/pages/discovery-v2/DiscoveryContainer.js
@@ -55,7 +55,7 @@ export const mapDispatchToProps = (dispatch, prevProps) => ({
     const { match } = prevProps
     const seenRecommendationIds =
       (shouldReloadRecommendations && []) ||
-      (recommendations && recommendations.map(reco => reco.id))
+      (recommendations && recommendations.map(reco => reco.offerId))
     let queryParams = getOfferIdAndMediationIdApiPathQueryString(match, currentRecommendation)
 
     dispatch(

--- a/src/components/pages/discovery-v2/__specs__/DiscoveryContainer.spec.js
+++ b/src/components/pages/discovery-v2/__specs__/DiscoveryContainer.spec.js
@@ -246,7 +246,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
           index: 1,
           offerId: 'ABC2',
         }
-        const recommendations = [{ id: 'AE3', index: 3 }]
+        const recommendations = [{ id: 'AE3', index: 3, offerId: 'AE4' }]
         const readRecommendations = null
         const shouldReloadRecommendations = false
         const functions = mapDispatchToProps(dispatch, props)
@@ -268,7 +268,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
             apiPath: `/recommendations/v2?`,
             body: {
               readRecommendations: null,
-              seenRecommendationIds: ['AE3'],
+              seenRecommendationIds: ['AE4'],
             },
             handleFail: handleRequestFail,
             handleSuccess: handleRequestSuccess,

--- a/src/components/pages/discovery-v3/DiscoveryContainer.js
+++ b/src/components/pages/discovery-v3/DiscoveryContainer.js
@@ -58,7 +58,7 @@ export const mapDispatchToProps = (dispatch, prevProps) => ({
   ) => {
     const seenRecommendationIds =
       (shouldReloadRecommendations && []) ||
-      (recommendations && recommendations.map(reco => reco.id))
+      (recommendations && recommendations.map(reco => reco.offerId))
     let queryParams = getCoordinatesApiPathQueryString(coordinates)
 
     dispatch(

--- a/src/components/pages/discovery-v3/__specs__/DiscoveryContainer.spec.js
+++ b/src/components/pages/discovery-v3/__specs__/DiscoveryContainer.spec.js
@@ -256,7 +256,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
           index: 1,
           offerId: 'ABC2',
         }
-        const recommendations = [{ id: 'AE3', index: 3 }]
+        const recommendations = [{ id: 'AE3', index: 3, offerId: 'AE4' }]
         const readRecommendations = null
         const shouldReloadRecommendations = false
         const functions = mapDispatchToProps(dispatch, props)
@@ -278,7 +278,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
             apiPath: `/recommendations/v3?`,
             body: {
               readRecommendations: null,
-              seenRecommendationIds: ['AE3'],
+              seenRecommendationIds: ['AE4'],
             },
             handleFail: handleRequestFail,
             handleSuccess: handleRequestSuccess,
@@ -298,7 +298,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
           index: 1,
           offerId: 'ABC2',
         }
-        const recommendations = [{ id: 'AE3', index: 3 }]
+        const recommendations = [{ id: 'AE3', index: 3, offerId: 'AE4' }]
         const readRecommendations = null
         const shouldReloadRecommendations = false
         const functions = mapDispatchToProps(dispatch, props)
@@ -322,7 +322,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
             apiPath: `/recommendations/v3?longitude=1.291&latitude=48.192`,
             body: {
               readRecommendations: null,
-              seenRecommendationIds: ['AE3'],
+              seenRecommendationIds: ['AE4'],
             },
             handleFail: handleRequestFail,
             handleSuccess: handleRequestSuccess,
@@ -342,7 +342,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
           index: 1,
           offerId: 'ABC2',
         }
-        const recommendations = [{ id: 'AE3', index: 3 }]
+        const recommendations = [{ id: 'AE3', index: 3, offerId: 'AE4' }]
         const readRecommendations = null
         const shouldReloadRecommendations = false
         const coordinates = {
@@ -370,7 +370,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
             apiPath: `/recommendations/v3?longitude=48.256756&latitude=2.8796567`,
             body: {
               readRecommendations: null,
-              seenRecommendationIds: ['AE3'],
+              seenRecommendationIds: ['AE4'],
             },
             handleFail: handleRequestFail,
             handleSuccess: handleRequestSuccess,
@@ -390,7 +390,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
           index: 1,
           offerId: 'ABC2',
         }
-        const recommendations = [{ id: 'AE3', index: 3 }]
+        const recommendations = [{ id: 'AE3', index: 3, offerId: 'AE4' }]
         const readRecommendations = null
         const shouldReloadRecommendations = false
         const coordinates = {
@@ -418,7 +418,7 @@ describe('src | components | pages | discovery | DiscoveryContainer', () => {
             apiPath: `/recommendations/v3?`,
             body: {
               readRecommendations: null,
-              seenRecommendationIds: ['AE3'],
+              seenRecommendationIds: ['AE4'],
             },
             handleFail: handleRequestFail,
             handleSuccess: handleRequestSuccess,


### PR DESCRIPTION
On envoyait les recoId avant et avec la vue matérialisée, on a besoin de l'offerId.
La v3 a été mise à jour aussi.