### PR TITLE
(PC-3121) Commented code to not show radius slider

### DIFF
--- a/src/components/pages/search-algolia/Filters/Filters.jsx
+++ b/src/components/pages/search-algolia/Filters/Filters.jsx
@@ -1,3 +1,6 @@
+//radiusRevert:
+/* eslint-disable no-unused-vars */
+
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
 import { Route, Switch } from 'react-router'
@@ -65,21 +68,21 @@ export class Filters extends PureComponent {
     const { aroundRadius, isSearchAroundMe, offerTypes, sortBy } = filters
     const offerCategories = this.getSelectedCategories()
 
-    isSearchAroundMe ?
-      this.fetchOffers({
-        aroundRadius,
-        keywords,
-        geolocation,
-        offerCategories,
-        offerTypes,
-        sortBy,
-      })
+    isSearchAroundMe
+      ? this.fetchOffers({
+          aroundRadius,
+          keywords,
+          geolocation,
+          offerCategories,
+          offerTypes,
+          sortBy,
+        })
       : this.fetchOffers({
-        keywords,
-        offerCategories,
-        offerTypes,
-        sortBy,
-      })
+          keywords,
+          offerCategories,
+          offerTypes,
+          sortBy,
+        })
 
     const autourDeMoi = checkIfAroundMe(filters.isSearchAroundMe)
     const categories = offerCategories.join(';') || ''
@@ -92,20 +95,23 @@ export class Filters extends PureComponent {
   resetFilters = () => {
     const { initialFilters } = this.props
 
-    this.setState({
-      filters: {
-        ...initialFilters,
-        aroundRadius: 0,
-        offerCategories: this.buildCategoriesStateFromProps(),
-        offerTypes: {
-          isDigital: false,
-          isEvent: false,
-          isThing: false
-        }
+    this.setState(
+      {
+        filters: {
+          ...initialFilters,
+          //radiusRevert: aroundRadius: 0,
+          offerCategories: this.buildCategoriesStateFromProps(),
+          offerTypes: {
+            isDigital: false,
+            isEvent: false,
+            isThing: false,
+          },
+        },
       },
-    }, () => {
-      this.process()
-    })
+      () => {
+        this.process()
+      }
+    )
   }
 
   getSelectedCategories = () => {
@@ -160,7 +166,8 @@ export class Filters extends PureComponent {
       {
         filters: {
           ...filters,
-          isSearchAroundMe: GEOLOCATION_CRITERIA[criterionKey].label === GEOLOCATION_CRITERIA.AROUND_ME.label
+          isSearchAroundMe:
+            GEOLOCATION_CRITERIA[criterionKey].label === GEOLOCATION_CRITERIA.AROUND_ME.label,
         },
       },
       () => {
@@ -197,47 +204,53 @@ export class Filters extends PureComponent {
     const { filters } = this.state
     const { offerTypes } = filters
 
-    this.setState({
-      filters: {
-        ...filters,
-        offerTypes: {
-          ...offerTypes,
-          [name]: checked,
+    this.setState(
+      {
+        filters: {
+          ...filters,
+          offerTypes: {
+            ...offerTypes,
+            [name]: checked,
+          },
         },
       },
-    }, () => {
-      this.process()
-    })
+      () => {
+        this.process()
+      }
+    )
   }
 
   handleOnCategoryChange = event => {
     const { name, checked } = event.target
     const { filters } = this.state
 
-    this.setState({
-      filters: {
-        ...filters,
-        offerCategories: {
-          ...filters.offerCategories,
-          [name]: checked,
+    this.setState(
+      {
+        filters: {
+          ...filters,
+          offerCategories: {
+            ...filters.offerCategories,
+            [name]: checked,
+          },
         },
       },
-    }, () => {
-      this.process()
-    })
+      () => {
+        this.process()
+      }
+    )
   }
 
   handleToggleCategories = () => () => {
     this.setState(prevState => ({ areCategoriesVisible: !prevState.areCategoriesVisible }))
   }
 
-  handleRadiusSlide = (value) => {
+  handleRadiusSlide = value => {
     const { filters } = this.state
 
     this.setState({
       filters: {
         ...filters,
-        aroundRadius: value
+        aroundRadius: value,
       },
     })
   }
@@ -292,26 +305,26 @@ export class Filters extends PureComponent {
                 </button>
                 <span className="sf-filter-separator" />
               </li>
-              {isSearchAroundMe && (
-                <li>
-                  <h4 className="sf-title">
-                    {'Rayon'}
-                  </h4>
-                  <h4 className="sf-slider-radius">
-                    {`${aroundRadius} km`}
-                  </h4>
-                  <div className="sf-slider-wrapper">
-                    <Slider
-                      max={100}
-                      min={0}
-                      onAfterChange={this.handleRadiusAfterSlide}
-                      onChange={this.handleRadiusSlide}
-                      value={aroundRadius}
-                    />
-                  </div>
-                  <span className="sf-filter-separator" />
-                </li>
-              )}
+              {/*//radiusRevert:{isSearchAroundMe && (*/}
+              {/*  <li>*/}
+              {/*    <h4 className="sf-title">*/}
+              {/*      {'Rayon'}*/}
+              {/*    </h4>*/}
+              {/*    <h4 className="sf-slider-radius">*/}
+              {/*      {`${aroundRadius} km`}*/}
+              {/*    </h4>*/}
+              {/*    <div className="sf-slider-wrapper">*/}
+              {/*      <Slider*/}
+              {/*        max={100}*/}
+              {/*        min={0}*/}
+              {/*        onAfterChange={this.handleRadiusAfterSlide}*/}
+              {/*        onChange={this.handleRadiusSlide}*/}
+              {/*        value={aroundRadius}*/}
+              {/*      />*/}
+              {/*    </div>*/}
+              {/*    <span className="sf-filter-separator" />*/}
+              {/*  </li>*/}
+              {/*)}*/}
               <li>
                 <button
                   aria-label="Afficher les catégories"
@@ -365,7 +378,7 @@ export class Filters extends PureComponent {
               <li>
                 <div className="sf-title-wrapper">
                   <h4 className="sf-title">
-                    {'Type d\'offres'}
+                    {"Type d'offres"}
                   </h4>
                   {numberOfOfferTypesSelected > 0 && (
                     <span className="sf-selected-filter-counter">
@@ -391,9 +404,9 @@ export class Filters extends PureComponent {
                     <FilterCheckbox
                       checked={offerTypes.isThing}
                       className={`${offerTypes.isThing ? 'fc-label-checked' : 'fc-label'}`}
-                      id='isThing'
-                      label='Offres physiques'
-                      name='isThing'
+                      id="isThing"
+                      label="Offres physiques"
+                      name="isThing"
                       onChange={this.handleOnTypeChange}
                     />
                   </li>
@@ -401,9 +414,9 @@ export class Filters extends PureComponent {
                     <FilterCheckbox
                       checked={offerTypes.isEvent}
                       className={`${offerTypes.isEvent ? 'fc-label-checked' : 'fc-label'}`}
-                      id='isEvent'
-                      label='Sorties'
-                      name='isEvent'
+                      id="isEvent"
+                      label="Sorties"
+                      name="isEvent"
                       onChange={this.handleOnTypeChange}
                     />
                   </li>

--- a/src/components/pages/search-algolia/Filters/__specs__/Filters.spec.jsx
+++ b/src/components/pages/search-algolia/Filters/__specs__/Filters.spec.jsx
@@ -38,7 +38,7 @@ describe('components | Filters', () => {
         offerTypes: {
           isDigital: false,
           isEvent: false,
-          isThing: false
+          isThing: false,
         },
         sortBy: '_by_price',
       },
@@ -107,9 +107,9 @@ describe('components | Filters', () => {
           props.isUserAllowedToSelectCriterion.mockReturnValue(true)
           props.query.parse.mockReturnValue({
             'autour-de-moi': 'non',
-            'categories': 'VISITE;CINEMA',
+            categories: 'VISITE;CINEMA',
             'mots-cles': 'librairie',
-            'tri': '_by_price',
+            tri: '_by_price',
           })
           fetchAlgolia.mockReturnValue(
             new Promise(resolve => {
@@ -140,7 +140,7 @@ describe('components | Filters', () => {
             offerTypes: {
               isDigital: false,
               isEvent: false,
-              isThing: false
+              isThing: false,
             },
             sortBy: '_by_price',
           })
@@ -164,16 +164,16 @@ describe('components | Filters', () => {
             offerTypes: {
               isDigital: false,
               isEvent: false,
-              isThing: false
+              isThing: false,
             },
             sortBy: '_by_price',
           }
           props.isUserAllowedToSelectCriterion.mockReturnValue(true)
           props.query.parse.mockReturnValue({
             'autour-de-moi': 'oui',
-            'categories': 'VISITE',
+            categories: 'VISITE',
             'mots-cles': 'librairie',
-            'tri': '_by_price',
+            tri: '_by_price',
           })
           fetchAlgolia.mockReturnValue(
             new Promise(resolve => {
@@ -206,9 +206,9 @@ describe('components | Filters', () => {
             offerTypes: {
               isDigital: false,
               isEvent: false,
-              isThing: false
+              isThing: false,
             },
-            sortBy: '_by_price'
+            sortBy: '_by_price',
           })
           expect(props.redirectToSearchFiltersPage).toHaveBeenCalledWith()
           expect(props.history.replace).toHaveBeenCalledWith({
@@ -230,7 +230,9 @@ describe('components | Filters', () => {
         // then
         const header = wrapper.find(HeaderContainer)
         expect(header).toHaveLength(1)
-        expect(header.prop('backTo')).toStrictEqual('/recherche-offres/resultats?mots-cles=librairie')
+        expect(header.prop('backTo')).toStrictEqual(
+          '/recherche-offres/resultats?mots-cles=librairie'
+        )
         expect(header.prop('closeTo')).toBeNull()
         expect(header.prop('reset')).toStrictEqual(expect.any(Function))
         expect(header.prop('title')).toStrictEqual('Filtrer')
@@ -295,7 +297,9 @@ describe('components | Filters', () => {
         resultsButton.simulate('click')
 
         // then
-        expect(props.history.push).toHaveBeenCalledWith('/recherche-offres/resultats?mots-cles=librairie')
+        expect(props.history.push).toHaveBeenCalledWith(
+          '/recherche-offres/resultats?mots-cles=librairie'
+        )
       })
 
       it('should redirect to results page with no query param when clicking on display results button', () => {
@@ -328,9 +332,9 @@ describe('components | Filters', () => {
           offerTypes: {
             isDigital: false,
             isEvent: false,
-            isThing: false
+            isThing: false,
           },
-          sortBy: '_by_price'
+          sortBy: '_by_price',
         })
       })
 
@@ -450,7 +454,9 @@ describe('components | Filters', () => {
           })
         })
 
-        describe('when geolocation filter is "Autour de moi"', () => {
+        //radiusRevert: added .skip to describe below and disabled eslint
+        // eslint-disable-next-line jest/no-disabled-tests
+        describe.skip('when geolocation filter is "Autour de moi"', () => {
           it('should display a "Rayon" title', () => {
             // given
             props.history.location.pathname = '/recherche-offres/filtres'
@@ -508,7 +514,7 @@ describe('components | Filters', () => {
           const wrapper = shallow(<Filters {...props} />)
 
           // then
-          const title = wrapper.findWhere(node => node.text() === 'Type d\'offres').first()
+          const title = wrapper.findWhere(node => node.text() === "Type d'offres").first()
           expect(title).toHaveLength(1)
         })
 
@@ -586,7 +592,9 @@ describe('components | Filters', () => {
           const wrapper = shallow(<Filters {...props} />)
 
           // then
-          const numberOfOfferTypesSelected = wrapper.findWhere(node => node.text() === '(3)').first()
+          const numberOfOfferTypesSelected = wrapper
+            .findWhere(node => node.text() === '(3)')
+            .first()
           expect(numberOfOfferTypesSelected).toHaveLength(1)
         })
 
@@ -603,7 +611,9 @@ describe('components | Filters', () => {
           const wrapper = shallow(<Filters {...props} />)
 
           // then
-          const numberOfOfferTypesSelected = wrapper.findWhere(node => node.text() === '(3)').first()
+          const numberOfOfferTypesSelected = wrapper
+            .findWhere(node => node.text() === '(3)')
+            .first()
           expect(numberOfOfferTypesSelected).toHaveLength(0)
         })
 
@@ -613,9 +623,10 @@ describe('components | Filters', () => {
           const wrapper = shallow(<Filters {...props} />)
           const digitalFilter = wrapper
             .find('[data-test="sf-offer-types-filter-wrapper"]')
-            .find(FilterCheckbox).at(0)
+            .find(FilterCheckbox)
+            .at(0)
           props.query.parse.mockReturnValue({
-            'mots-cles': 'librairies'
+            'mots-cles': 'librairies',
           })
           fetchAlgolia.mockReturnValue(
             new Promise(resolve => {
@@ -631,8 +642,8 @@ describe('components | Filters', () => {
           digitalFilter.simulate('change', {
             target: {
               name: 'isDigital',
-              checked: true
-            }
+              checked: true,
+            },
           })
 
           // then
@@ -642,9 +653,9 @@ describe('components | Filters', () => {
             offerTypes: {
               isDigital: true,
               isEvent: false,
-              isThing: false
+              isThing: false,
             },
-            sortBy: '_by_price'
+            sortBy: '_by_price',
           })
         })
       })
@@ -689,7 +700,9 @@ describe('components | Filters', () => {
           const categoriesButtonAfterClick = wrapper
             .findWhere(node => node.text() === 'Catégories')
             .at(1)
-          expect(categoriesButtonClassNameBeforeClick).toBe('sf-category-title-wrapper sf-title-drop-down')
+          expect(categoriesButtonClassNameBeforeClick).toBe(
+            'sf-category-title-wrapper sf-title-drop-down'
+          )
           expect(categoriesButtonAfterClick.prop('className')).toBe(
             'sf-category-title-wrapper sf-title-drop-down-flipped'
           )
@@ -836,8 +849,7 @@ describe('components | Filters', () => {
           it('should reset filters and trigger search to Algolia with given category', () => {
             // given
             props.history = createBrowserHistory()
-            jest.spyOn(props.history, 'replace').mockImplementationOnce(() => {
-            })
+            jest.spyOn(props.history, 'replace').mockImplementationOnce(() => {})
             props.history.location.pathname = '/recherche-offres/resultats/filtres'
             props.initialFilters = {
               isSearchAroundMe: true,
@@ -845,9 +857,9 @@ describe('components | Filters', () => {
               offerTypes: {
                 isDigital: false,
                 isEvent: false,
-                isThing: false
+                isThing: false,
               },
-              sortBy: '_by_price'
+              sortBy: '_by_price',
             }
             props.query.parse.mockReturnValue({
               'mots-cles': 'librairie',
@@ -876,14 +888,14 @@ describe('components | Filters', () => {
 
             // then
             expect(fetchAlgolia).toHaveBeenCalledWith({
-              aroundRadius: 0,
+              //radiusRevert: aroundRadius: 0,
               geolocation: { latitude: 40, longitude: 41 },
               keywords: 'librairie',
               offerCategories: ['VISITE'],
               offerTypes: {
                 isDigital: false,
                 isEvent: false,
-                isThing: false
+                isThing: false,
               },
               sortBy: '_by_price',
             })
@@ -894,8 +906,7 @@ describe('components | Filters', () => {
           it('should reset filters and trigger search to Algolia with given categories', () => {
             // given
             props.history = createBrowserHistory()
-            jest.spyOn(props.history, 'replace').mockImplementationOnce(() => {
-            })
+            jest.spyOn(props.history, 'replace').mockImplementationOnce(() => {})
             props.history.location.pathname = '/recherche-offres/resultats/filtres'
             props.initialFilters = {
               isSearchAroundMe: true,
@@ -903,9 +914,9 @@ describe('components | Filters', () => {
               offerTypes: {
                 isDigital: true,
                 isEvent: true,
-                isThing: true
+                isThing: true,
               },
-              sortBy: '_by_price'
+              sortBy: '_by_price',
             }
             props.query.parse.mockReturnValue({
               'mots-cles': 'librairie',
@@ -934,14 +945,14 @@ describe('components | Filters', () => {
 
             // then
             expect(fetchAlgolia).toHaveBeenCalledWith({
-              aroundRadius: 0,
+              //radiusRevert: aroundRadius: 0,
               geolocation: { latitude: 40, longitude: 41 },
               keywords: 'librairie',
               offerCategories: ['VISITE', 'CINEMA'],
               offerTypes: {
                 isDigital: false,
                 isEvent: false,
-                isThing: false
+                isThing: false,
               },
               sortBy: '_by_price',
             })

--- a/src/components/pages/search-algolia/Result/SearchResults.jsx
+++ b/src/components/pages/search-algolia/Result/SearchResults.jsx
@@ -16,12 +16,14 @@ import SearchAlgoliaDetailsContainer from './ResultDetail/ResultDetailContainer'
 class SearchResults extends PureComponent {
   constructor(props) {
     super(props)
-    const { criteria: { categories, isSearchAroundMe, sortBy } } = props
+    const {
+      criteria: { categories, isSearchAroundMe, sortBy },
+    } = props
 
     this.state = {
       currentPage: 0,
       filters: {
-        aroundRadius: 0,
+        //radiusRevert: aroundRadius: 0,
         isSearchAroundMe: this.getIsSearchAroundMeFromUrlOrProps(isSearchAroundMe),
         offerCategories: this.getCategoriesFromUrlOrProps(categories),
         offerTypes: {
@@ -29,7 +31,7 @@ class SearchResults extends PureComponent {
           isEvent: false,
           isThing: false,
         },
-        sortBy: this.getSortByFromUrlOrProps(sortBy)
+        sortBy: this.getSortByFromUrlOrProps(sortBy),
       },
       keywordsToSearch: '',
       isLoading: false,
@@ -49,7 +51,7 @@ class SearchResults extends PureComponent {
     this.fetchOffers(keywords, currentPage)
   }
 
-  getCategoriesFromUrlOrProps = (categoriesFromProps) => {
+  getCategoriesFromUrlOrProps = categoriesFromProps => {
     const { query } = this.props
     const queryParams = query.parse()
     const categoriesFromUrl = queryParams['categories'] || ''
@@ -57,7 +59,7 @@ class SearchResults extends PureComponent {
     return categoriesFromUrl ? categoriesFromUrl.split(';') : categoriesFromProps
   }
 
-  getIsSearchAroundMeFromUrlOrProps = (isSearchAroundMeFromProps) => {
+  getIsSearchAroundMeFromUrlOrProps = isSearchAroundMeFromProps => {
     const { query } = this.props
     const queryParams = query.parse()
     const isSearchAroundMeFromUrl = queryParams['autour-de-moi'] || ''
@@ -65,7 +67,7 @@ class SearchResults extends PureComponent {
     return isSearchAroundMeFromUrl ? isSearchAroundMeFromUrl === 'oui' : isSearchAroundMeFromProps
   }
 
-  getSortByFromUrlOrProps = (sortByFromProps) => {
+  getSortByFromUrlOrProps = sortByFromProps => {
     const { query } = this.props
     const queryParams = query.parse()
     const sortByFromUrl = queryParams['tri'] || ''
@@ -76,7 +78,7 @@ class SearchResults extends PureComponent {
   getScrollParent = () => document.querySelector('.sr-wrapper')
 
   showFailModal = () => {
-    toast.info('La recherche n\'a pas pu aboutir, veuillez ré-essayer plus tard.')
+    toast.info("La recherche n'a pas pu aboutir, veuillez ré-essayer plus tard.")
   }
 
   handleOnSubmit = event => {
@@ -93,18 +95,21 @@ class SearchResults extends PureComponent {
     const tri = queryParams['tri']
 
     trimmedKeywordsToSearch &&
-    history.replace({
-      search: `?mots-cles=${trimmedKeywordsToSearch}&autour-de-moi=${autourDeMoi}&tri=${tri}&categories=${categories}`,
-    })
+      history.replace({
+        search: `?mots-cles=${trimmedKeywordsToSearch}&autour-de-moi=${autourDeMoi}&tri=${tri}&categories=${categories}`,
+      })
 
     if (searchedKeywords !== trimmedKeywordsToSearch) {
-      this.setState({
-        currentPage: 0,
-        results: [],
-      }, () => {
-        const { currentPage } = this.state
-        this.fetchOffers(trimmedKeywordsToSearch, currentPage)
-      })
+      this.setState(
+        {
+          currentPage: 0,
+          results: [],
+        },
+        () => {
+          const { currentPage } = this.state
+          this.fetchOffers(trimmedKeywordsToSearch, currentPage)
+        }
+      )
     }
     this.inputRef.current.blur()
   }
@@ -146,24 +151,26 @@ class SearchResults extends PureComponent {
       options.geolocation = geolocation
     }
 
-    fetchAlgolia(options).then(offers => {
-      const { results } = this.state
-      const { hits, nbHits, nbPages } = offers
-      this.setState({
-        currentPage: page,
-        keywordsToSearch: keywords,
-        isLoading: false,
-        resultsCount: nbHits,
-        results: [...results, ...hits],
-        searchedKeywords: keywords,
-        totalPagesNumber: nbPages,
+    fetchAlgolia(options)
+      .then(offers => {
+        const { results } = this.state
+        const { hits, nbHits, nbPages } = offers
+        this.setState({
+          currentPage: page,
+          keywordsToSearch: keywords,
+          isLoading: false,
+          resultsCount: nbHits,
+          results: [...results, ...hits],
+          searchedKeywords: keywords,
+          totalPagesNumber: nbPages,
+        })
       })
-    }).catch(() => {
-      this.setState({
-        isLoading: false,
+      .catch(() => {
+        this.setState({
+          isLoading: false,
+        })
+        this.showFailModal()
       })
-      this.showFailModal()
-    })
   }
 
   fetchNextOffers = currentPage => {
@@ -220,7 +227,15 @@ class SearchResults extends PureComponent {
 
   render() {
     const { geolocation, history, match, query } = this.props
-    const { currentPage, filters, keywordsToSearch, isLoading, results, resultsCount, totalPagesNumber } = this.state
+    const {
+      currentPage,
+      filters,
+      keywordsToSearch,
+      isLoading,
+      results,
+      resultsCount,
+      totalPagesNumber,
+    } = this.state
     const { isSearchAroundMe } = filters
     const { location } = history
     const { search } = location
@@ -319,9 +334,7 @@ class SearchResults extends PureComponent {
               </button>
             </div>
           </Route>
-          <Route
-            path="/recherche-offres/resultats/:details(details|transition)/:offerId([A-Z0-9]+)(/menu)?/:booking(reservation)?/:bookingId([A-Z0-9]+)?/:cancellation(annulation)?/:confirmation(confirmation)?"
-          >
+          <Route path="/recherche-offres/resultats/:details(details|transition)/:offerId([A-Z0-9]+)(/menu)?/:booking(reservation)?/:bookingId([A-Z0-9]+)?/:cancellation(annulation)?/:confirmation(confirmation)?">
             <HeaderContainer
               closeTitle="Retourner à la page découverte"
               closeTo="/decouverte"

--- a/src/components/pages/search-algolia/Result/__specs__/SearchResults.spec.jsx
+++ b/src/components/pages/search-algolia/Result/__specs__/SearchResults.spec.jsx
@@ -53,7 +53,7 @@ describe('components | SearchResults', () => {
       criteria: {
         categories: [],
         isSearchAroundMe: false,
-        sortBy: null
+        sortBy: null,
       },
       geolocation: {
         latitude: 40.1,
@@ -169,7 +169,7 @@ describe('components | SearchResults', () => {
       parse.mockReturnValue({
         categories: 'MUSEE',
         'mots-cles': 'une librairie',
-        tri: '_by_price'
+        tri: '_by_price',
       })
       props.criteria = {}
 
@@ -183,7 +183,7 @@ describe('components | SearchResults', () => {
         offerTypes: {
           isDigital: false,
           isEvent: false,
-          isThing: false
+          isThing: false,
         },
         page: 0,
         sortBy: '_by_price',
@@ -195,7 +195,7 @@ describe('components | SearchResults', () => {
         props.criteria = {
           categories: ['Cinéma'],
           isSearchAroundMe: true,
-          sortBy: '_by_proximity'
+          sortBy: '_by_proximity',
         }
 
         // when
@@ -203,7 +203,7 @@ describe('components | SearchResults', () => {
 
         // then
         expect(fetchAlgolia).toHaveBeenCalledWith({
-          aroundRadius: 0,
+          //radiusRevert: aroundRadius: 0,
           geolocation: props.geolocation,
           keywords: '',
           offerCategories: ['Cinéma'],
@@ -241,9 +241,7 @@ describe('components | SearchResults', () => {
         // then
         const results = wrapper.find(Result)
         const searchInput = wrapper.find('input')
-        const resultTitle = wrapper
-          .findWhere(node => node.text() === '0 résultat')
-          .first()
+        const resultTitle = wrapper.findWhere(node => node.text() === '0 résultat').first()
         expect(results).toHaveLength(0)
         expect(searchInput.prop('value')).toBe('une librairie')
         expect(resultTitle).toHaveLength(1)
@@ -282,9 +280,7 @@ describe('components | SearchResults', () => {
         // then
         const results = wrapper.find(Result)
         const searchInput = wrapper.find('input')
-        const resultTitle = wrapper
-          .findWhere(node => node.text() === '2 résultats')
-          .first()
+        const resultTitle = wrapper.findWhere(node => node.text() === '2 résultats').first()
         expect(results).toHaveLength(2)
         expect(results.at(0).prop('geolocation')).toStrictEqual(props.geolocation)
         expect(results.at(0).prop('result')).toStrictEqual({ objectID: 'AA' })
@@ -318,9 +314,7 @@ describe('components | SearchResults', () => {
         // then
         const results = wrapper.find(Result)
         const searchInput = wrapper.find('input')
-        const resultTitle = wrapper
-          .findWhere(node => node.text() === '2 résultats')
-          .first()
+        const resultTitle = wrapper.findWhere(node => node.text() === '2 résultats').first()
         expect(results).toHaveLength(2)
         expect(results.at(0).prop('geolocation')).toStrictEqual({})
         expect(results.at(0).prop('result')).toStrictEqual({ objectID: 'AA' })
@@ -356,7 +350,7 @@ describe('components | SearchResults', () => {
 
         // then
         expect(fetchAlgolia).toHaveBeenCalledWith({
-          aroundRadius: 0,
+          //radiusRevert: aroundRadius: 0,
           geolocation: { latitude: 40.1, longitude: 41.1 },
           keywords: 'une librairie',
           offerCategories: [],
@@ -419,7 +413,7 @@ describe('components | SearchResults', () => {
         )
         parse.mockReturnValue({
           categories: 'CINEMA',
-          'mots-cles': 'une librairie'
+          'mots-cles': 'une librairie',
         })
         props.criteria = {}
 
@@ -496,7 +490,7 @@ describe('components | SearchResults', () => {
             isThing: false,
           },
           page: 0,
-          sortBy: null
+          sortBy: null,
         })
       })
     })
@@ -515,7 +509,7 @@ describe('components | SearchResults', () => {
         )
         parse.mockReturnValue({
           'mots-cles': 'une librairie',
-          tri: '_by_proximity'
+          tri: '_by_proximity',
         })
 
         // when
@@ -549,7 +543,7 @@ describe('components | SearchResults', () => {
         )
         parse.mockReturnValue({
           'mots-cles': 'une librairie',
-          tri: ''
+          tri: '',
         })
 
         // when
@@ -582,11 +576,11 @@ describe('components | SearchResults', () => {
         )
         props.criteria = {
           categories: [],
-          isSearchAroundMe: false
+          isSearchAroundMe: false,
         }
         parse.mockReturnValue({
           'mots-cles': 'une librairie',
-          tri: ''
+          tri: '',
         })
 
         // when
@@ -730,9 +724,7 @@ describe('components | SearchResults', () => {
       })
 
       // then
-      const resultTitle = wrapper
-        .findWhere(node => node.text() === '0 résultat')
-        .first()
+      const resultTitle = wrapper.findWhere(node => node.text() === '0 résultat').first()
       expect(resultTitle).toHaveLength(1)
     })
 
@@ -767,9 +759,7 @@ describe('components | SearchResults', () => {
       })
 
       // then
-      const resultTitle = wrapper
-        .findWhere(node => node.text() === '2 résultats')
-        .first()
+      const resultTitle = wrapper.findWhere(node => node.text() === '2 résultats').first()
       expect(resultTitle).toHaveLength(1)
     })
 
@@ -894,7 +884,7 @@ describe('components | SearchResults', () => {
             hitsPerPage: 2,
             processingTimeMS: 1,
             query: 'librairie',
-            params: 'query=\'librairie\'&hitsPerPage=2',
+            params: "query='librairie'&hitsPerPage=2",
           })
         })
       )
@@ -927,7 +917,7 @@ describe('components | SearchResults', () => {
             hitsPerPage: 2,
             processingTimeMS: 1,
             query: 'vas-y',
-            params: "query=\"vas-y\"&hitsPerPage=2",
+            params: 'query="vas-y"&hitsPerPage=2',
           })
         })
       )
@@ -946,7 +936,7 @@ describe('components | SearchResults', () => {
       expect(wrapper.state()).toStrictEqual({
         currentPage: 0,
         filters: {
-          aroundRadius: 0,
+          //radiusRevert: aroundRadius: 0,
           isSearchAroundMe: false,
           offerCategories: [],
           offerTypes: {
@@ -954,7 +944,7 @@ describe('components | SearchResults', () => {
             isEvent: false,
             isThing: false,
           },
-          sortBy: null
+          sortBy: null,
         },
         keywordsToSearch: 'vas-y',
         isLoading: false,
@@ -1016,7 +1006,7 @@ describe('components | SearchResults', () => {
           isThing: false,
         },
         page: 0,
-        sortBy: null
+        sortBy: null,
       })
       expect(fetchAlgolia).toHaveBeenNthCalledWith(2, {
         keywords: 'librairie',
@@ -1392,9 +1382,9 @@ describe('components | SearchResults', () => {
       // given
       history.push('/recherche-offres/resultats/filtres')
       props.query.parse.mockReturnValue({
-        'categories': 'VISITE;CINEMA',
+        categories: 'VISITE;CINEMA',
         'mots-cles': 'librairie',
-        'tri': '_by_price',
+        tri: '_by_price',
       })
 
       // when
@@ -1411,7 +1401,7 @@ describe('components | SearchResults', () => {
       expect(filtersContainer).toHaveLength(1)
       expect(filtersContainer.prop('history')).toStrictEqual(props.history)
       expect(filtersContainer.prop('initialFilters')).toStrictEqual({
-        aroundRadius: 0,
+        //radiusRevert: aroundRadius: 0,
         isSearchAroundMe: false,
         offerCategories: ['VISITE', 'CINEMA'],
         offerTypes: {


### PR DESCRIPTION
Je ne suis pas parvenu à faire un revert digne de ce nom, il y avait trop de commits dans la feature, incluant trop de refacto sur lequel les commits d'autres features s'appuyaient. Donc la résolution de conflit, pour qu'elle passe supprimait aussi les fonctionnalités des commits d'après. J'ai donc mis en commentaire les parties de code afin de désactiver juste cette fonctionnalité de slider kilométrique. J'ai préfixé chaque commentaire de `//radiusRevert:` pour que ce soit plus simple de les retrouver afin de les enlever. Je n'aime pas ça du tout, mais je n'ai pas mieux.