### PR TITLE
(pC-3222): transform recommendations cached selectors to normal selector 

### DIFF
--- a/src/components/pages/discovery-v2/selectors/selectCurrentRecommendation.js
+++ b/src/components/pages/discovery-v2/selectors/selectCurrentRecommendation.js
@@ -1,14 +1,13 @@
 import selectIndexifiedRecommendations from './selectIndexifiedRecommendations'
-import createCachedSelector from 're-reselect'
-import mapArgsToCacheKey from './mapArgsToCacheKey'
+import { createSelector } from 'reselect'
 
-const selectCurrentRecommendation = createCachedSelector(
+const selectCurrentRecommendation = createSelector(
   selectIndexifiedRecommendations,
   (state, offerId) => offerId,
   (recommendations, offerId) =>
     recommendations.find(recommendation => {
       return offerId === recommendation.offerId
     })
-)(mapArgsToCacheKey)
+)
 
 export default selectCurrentRecommendation

--- a/src/components/pages/discovery-v2/selectors/selectNextRecommendation.js
+++ b/src/components/pages/discovery-v2/selectors/selectNextRecommendation.js
@@ -1,9 +1,8 @@
 import selectCurrentRecommendation from './selectCurrentRecommendation'
 import selectIndexifiedRecommendations from './selectIndexifiedRecommendations'
-import createCachedSelector from 're-reselect'
-import mapArgsToCacheKey from './mapArgsToCacheKey'
+import { createSelector } from 'reselect'
 
-const selectNextRecommendation = createCachedSelector(
+const selectNextRecommendation = createSelector(
   selectIndexifiedRecommendations,
   selectCurrentRecommendation,
   (recommendations, currentRecommendation) => {
@@ -20,6 +19,6 @@ const selectNextRecommendation = createCachedSelector(
 
     return nextRecommendation
   }
-)(mapArgsToCacheKey)
+)
 
 export default selectNextRecommendation

--- a/src/components/pages/discovery-v2/selectors/selectPreviousRecommendation.js
+++ b/src/components/pages/discovery-v2/selectors/selectPreviousRecommendation.js
@@ -1,10 +1,9 @@
-import createCachedSelector from 're-reselect'
+import { createSelector } from 'reselect'
 
-import mapArgsToCacheKey from './mapArgsToCacheKey'
 import selectCurrentRecommendation from './selectCurrentRecommendation'
 import selectIndexifiedRecommendations from './selectIndexifiedRecommendations'
 
-const selectPreviousRecommendation = createCachedSelector(
+const selectPreviousRecommendation = createSelector(
   selectIndexifiedRecommendations,
   selectCurrentRecommendation,
   (recommendations, currentRecommendation) => {
@@ -23,6 +22,6 @@ const selectPreviousRecommendation = createCachedSelector(
 
     return previousRecommendation
   }
-)(mapArgsToCacheKey)
+)
 
 export default selectPreviousRecommendation

--- a/src/components/pages/discovery-v3/selectors/selectCurrentRecommendation.js
+++ b/src/components/pages/discovery-v3/selectors/selectCurrentRecommendation.js
@@ -1,14 +1,13 @@
 import selectIndexifiedRecommendations from './selectIndexifiedRecommendations'
-import createCachedSelector from 're-reselect'
-import mapArgsToCacheKey from './mapArgsToCacheKey'
+import { createSelector } from 'reselect'
 
-const selectCurrentRecommendation = createCachedSelector(
+const selectCurrentRecommendation = createSelector(
   selectIndexifiedRecommendations,
   (state, offerId) => offerId,
   (recommendations, offerId) =>
     recommendations.find(recommendation => {
       return offerId === recommendation.offerId
     })
-)(mapArgsToCacheKey)
+)
 
 export default selectCurrentRecommendation

--- a/src/components/pages/discovery-v3/selectors/selectNextRecommendation.js
+++ b/src/components/pages/discovery-v3/selectors/selectNextRecommendation.js
@@ -1,9 +1,8 @@
 import selectCurrentRecommendation from './selectCurrentRecommendation'
 import selectIndexifiedRecommendations from './selectIndexifiedRecommendations'
-import createCachedSelector from 're-reselect'
-import mapArgsToCacheKey from './mapArgsToCacheKey'
+import { createSelector } from 'reselect'
 
-const selectNextRecommendation = createCachedSelector(
+const selectNextRecommendation = createSelector(
   selectIndexifiedRecommendations,
   selectCurrentRecommendation,
   (recommendations, currentRecommendation) => {
@@ -20,6 +19,6 @@ const selectNextRecommendation = createCachedSelector(
 
     return nextRecommendation
   }
-)(mapArgsToCacheKey)
+)
 
 export default selectNextRecommendation

--- a/src/components/pages/discovery-v3/selectors/selectPreviousRecommendation.js
+++ b/src/components/pages/discovery-v3/selectors/selectPreviousRecommendation.js
@@ -1,10 +1,8 @@
-import createCachedSelector from 're-reselect'
-
-import mapArgsToCacheKey from './mapArgsToCacheKey'
+import { createSelector } from 'reselect'
 import selectCurrentRecommendation from './selectCurrentRecommendation'
 import selectIndexifiedRecommendations from './selectIndexifiedRecommendations'
 
-const selectPreviousRecommendation = createCachedSelector(
+const selectPreviousRecommendation = createSelector(
   selectIndexifiedRecommendations,
   selectCurrentRecommendation,
   (recommendations, currentRecommendation) => {
@@ -23,6 +21,6 @@ const selectPreviousRecommendation = createCachedSelector(
 
     return previousRecommendation
   }
-)(mapArgsToCacheKey)
+)
 
 export default selectPreviousRecommendation


### PR DESCRIPTION
**Actuellement** : 
SelectCurrentRecommendation, SelectPreviousRecommendation et SelectNextRecommendation sont des sélecteurs crées avec re-reselect qui cache dans le service worker ces sélecteurs.

Il s'avère que ces sélecteurs ont changé et ne se base plus sur les mêmes données. Il n'y a plus de filtres sur les tutoriels par exemple.

Du coup, pour que le carrousel re-fonctionne actuellement, il faut vider les données enregistrées dans le service worker de l’application.

**Dans cette PR** : 
- On remplace les sélecteurs cachés par des sélecteurs normaux.