### PR TITLE
(PC-4118): Get thumbUrl via offer instead of booking

### DIFF
--- a/src/components/layout/Recto/RectoContainer.js
+++ b/src/components/layout/Recto/RectoContainer.js
@@ -8,6 +8,7 @@ import { selectMediationByOfferId } from '../../../redux/selectors/data/mediatio
 import { selectThumbUrlByRouterMatch } from '../../../redux/selectors/data/thumbUrlSelector'
 import { selectBookingById } from '../../../redux/selectors/data/bookingsSelectors'
 import { selectStockById } from '../../../redux/selectors/data/stocksSelectors'
+import { selectOfferById } from '../../../redux/selectors/data/offersSelectors'
 
 export const mapStateToProps = (state, ownProps) => {
   const { match, recommendation } = ownProps
@@ -30,11 +31,12 @@ export const findThumbByBookingId = (state, bookingId) => {
   const stock = selectStockById(state, stockId)
   const { offerId = '' } = stock || {}
   const mediation = selectMediationByOfferId(state, offerId)
+  const offer = selectOfferById(state, offerId)
 
   if (mediation) {
     withMediation = true
   }
-  thumbUrl = booking.thumbUrl ? booking.thumbUrl : DEFAULT_THUMB_URL
+  thumbUrl = offer.thumbUrl ? offer.thumbUrl : DEFAULT_THUMB_URL
 
   return {
     thumbUrl,

--- a/src/components/layout/Recto/__specs__/RectoContainer.spec.js
+++ b/src/components/layout/Recto/__specs__/RectoContainer.spec.js
@@ -17,9 +17,9 @@ describe('components | RectoContainer', () => {
       }
       const state = {
         data: {
-          bookings: [{ id: 'AB', stockId: 'AC', thumbUrl: '/url-to-image/from-booking' }],
+          bookings: [{ id: 'AB', stockId: 'AC' }],
           mediations: [{ id: 'AE', offerId: 'AD' }],
-          offers: [{ id: 'AD', product: {} }],
+          offers: [{ id: 'AD', product: {}, thumbUrl: '/url-to-image/from-booking' }],
           stocks: [{ id: 'AC', offerId: 'AD' }],
         },
       }
@@ -76,9 +76,9 @@ describe('components | RectoContainer', () => {
       }
       const state = {
         data: {
-          bookings: [{ id: 'AB', stockId: 'AC', thumbUrl: '/url-to-image/from-booking' }],
+          bookings: [{ id: 'AB', stockId: 'AC' }],
           mediations: [{ id: 'AE', offerId: 'AD', thumbUrl: '/url-to-image' }],
-          offers: [{ id: 'AD', product: {} }],
+          offers: [{ id: 'AD', product: {}, thumbUrl: '/url-to-image/from-booking' }],
           stocks: [{ id: 'AC', offerId: 'AD' }],
         },
       }
@@ -102,9 +102,15 @@ describe('components | RectoContainer', () => {
       }
       const state = {
         data: {
-          bookings: [{ id: 'AB', stockId: 'AC', thumbUrl: '/url-to-image/from-booking' }],
+          bookings: [{ id: 'AB', stockId: 'AC' }],
           mediations: [],
-          offers: [{ id: 'AD', product: { id: 'AE', thumbUrl: '/url-to-image/from-product' } }],
+          offers: [
+            {
+              id: 'AD',
+              product: { id: 'AE', thumbUrl: '/url-to-image/from-product' },
+              thumbUrl: '/url-to-image/from-booking',
+            },
+          ],
           stocks: [{ id: 'AC', offerId: 'AD' }],
         },
       }
@@ -217,7 +223,7 @@ describe('components | RectoContainer', () => {
         data: {
           bookings: [],
           mediations: [],
-          offers: [{ id: 'AD', thumbUrl: "/url-to-image-from-offer" }],
+          offers: [{ id: 'AD', thumbUrl: '/url-to-image-from-offer' }],
           stocks: [{ id: 'AC', offerId: 'AD' }],
         },
       }

--- a/src/components/pages/my-bookings/MyBookingsLists/BookingsList/BookingItem/BookingItem.jsx
+++ b/src/components/pages/my-bookings/MyBookingsLists/BookingsList/BookingItem/BookingItem.jsx
@@ -125,7 +125,6 @@ BookingItem.propTypes = {
     id: PropTypes.string,
     qrCode: PropTypes.string,
     quantity: PropTypes.number,
-    thumbUrl: PropTypes.string,
     token: PropTypes.string.isRequired,
   }).isRequired,
   isQrCodeFeatureDisabled: PropTypes.bool.isRequired,

--- a/src/components/pages/my-bookings/MyBookingsLists/BookingsList/BookingItem/__specs__/BookingItem.spec.jsx
+++ b/src/components/pages/my-bookings/MyBookingsLists/BookingsList/BookingItem/__specs__/BookingItem.spec.jsx
@@ -18,7 +18,6 @@ describe('src | components | pages | my-bookings | MyBookingsList | BookingList 
         qrCode: 'data:image/png;base64,iVIVhzdjeizfjezfoizejojczez',
         stock: {},
         token: 'G9G9G9',
-        thumbUrl: '/mediations/AE',
       },
       isQrCodeFeatureDisabled: true,
       location: {
@@ -133,7 +132,7 @@ describe('src | components | pages | my-bookings | MyBookingsList | BookingList 
 
   it('should render a booking with a thumb url on thumb when mediation is provided', () => {
     // given
-    props.booking.thumbUrl = '/mediations/AE'
+    props.offer.thumbUrl = '/mediations/AE'
 
     // when
     const wrapper = shallow(<BookingItem {...props} />)

--- a/src/redux/selectors/data/thumbUrlSelector.js
+++ b/src/redux/selectors/data/thumbUrlSelector.js
@@ -14,10 +14,6 @@ export const selectThumbUrlByRouterMatch = createCachedSelector(
       return mediation.thumbUrl
     }
 
-    if (booking && booking.thumbUrl) {
-      return booking.thumbUrl
-    }
-
     if (offer && offer.thumbUrl) {
       return offer.thumbUrl
     }


### PR DESCRIPTION
Modification de la manière dont on récupère le thumbUrl pour les détails d'un booking, cette propriété n'étant plus contenue dans l'objet booking mais dans l'objet offer.